### PR TITLE
Improve some links for March 2020 meeting notes

### DIFF
--- a/meetings/2020-03/april-1.md
+++ b/meetings/2020-03/april-1.md
@@ -483,7 +483,7 @@ Mark S. Miller (@Agoric )
 
 ### Conclusion/Resolution
 - consensus to remove FinalizationRegistry cleanup iterators and pass values directly
-- SYG will follow up with KM on cleanupSome before the end of this meeting.
+- SYG will follow up with KM on cleanupSome before the end of this meeting ([link](https://github.com/tc39/notes/blob/master/meetings/2020-03/april-2.md#revisit-weakrefs-finalizationregistry-api-change)).
 
 ## Temporal update
 
@@ -789,7 +789,7 @@ RPR: No objections. You have stage 1.
 ### Conclusion/Resolution
 -  Consensus reached for Intl.NumberFormat V3 for Stage 1.
 
-## import.meta for Stage 4 (continued from previous day)
+## import.meta for Stage 4 ([continued from previous day](https://github.com/tc39/notes/blob/master/meetings/2020-03/march-31.md#importmeta-for-stage-4))
 
 Presenter: Gus Caplan (GCL) and Myles Borins (MBS)
 

--- a/meetings/2020-03/april-2.md
+++ b/meetings/2020-03/april-2.md
@@ -378,8 +378,9 @@ RW: I also just had some of the same conversations on that topic.
 
 Presenter: Keith Miller (KM)
 
-- [proposal](url)
-- [slides](url)
+- [previous discussion on April 1](https://github.com/tc39/notes/blob/master/meetings/2020-03/april-1.md#weakrefs-finalizationregistry-api-change)
+- [pull request](https://github.com/tc39/proposal-weakrefs/pull/187)
+- [slides](https://docs.google.com/presentation/d/1mT9qcho2gGGDTNFd5KnOTvweJ9NFM_fbmxbGnZz5H4s/edit)
 
 KM: (presents slides)
 

--- a/meetings/2020-03/march-31.md
+++ b/meetings/2020-03/march-31.md
@@ -1031,7 +1031,7 @@ MM: It sounded like anyone who would be fine with both host hooks should be fine
 MBS: We have more time tomorrow. Let’s put a 15 minute time box for tomorrow at the end of the day.
 
 ### Conclusion/Resolution
-- Will continue discussion tomorrow in a 15 minute timebox.
+- Will continue discussion [tomorrow](https://github.com/tc39/notes/blob/master/meetings/2020-03/april-1.md#importmeta-for-stage-4-continued-from-previous-day) in a 15 minute timebox.
 
 New Topic: Do we need to worry about this prior to Compartments actually exposing hooks?
 Jordan Harband


### PR DESCRIPTION
I've added missing links and crosslinking (between different days) for some proposals