### PR TITLE
Add notes for Sept 2020

### DIFF
--- a/meetings/2020-09/sept-21.md
+++ b/meetings/2020-09/sept-21.md
@@ -1,0 +1,796 @@
+# September 21, 2020 Meeting Notes
+-----
+
+**In-person attendees:**  
+
+**Remote attendees:** 
+| Name                 | Abbreviation   | Organization       |
+| -------------------- | -------------- | ------------------ |
+| Waldemar Horwat      | WH             | Google             |
+| Ross Kirsling        | RKG            | Sony               |
+| Bradford C. Smith    | BSH            | Google             |
+| Philip Chimento      | PFC            | Igalia             |
+| Richard Gibson       | RGN            | OpenJS Foundation  |
+| Michael Saboff       | MLS            | Apple              |
+| Dave Poole           | DMP            | Apple              |
+| Keith Miller         | KM             | Apple              |
+| Jack Works           | JWK            | Sujitech           |
+| Chip Morningstar     | CM             | Agoric             |
+| Daniel Ehrenberg     | DE             | Igalia             |
+| Myles Borins         | MBS            | GitHub / Microsoft |
+| Jordan Harband       | JHD            | Invited Expert     |
+| Leo Balter           | LEO            | Salesforce         |
+| Ujjwal Sharma        | USA            | Igalia             |
+| Justin Ridgewell     | JRL            | Google             |
+| Shane F. Carr        | SFC            | Google             |
+| SongYang Pu          | SYP            | Alibaba            |
+| Chengzhong Wu        | CZW            | Alibaba            |
+| Jason Orendorff      | JTO            | Mozilla            |
+| Rob Palmer           | RPR            | Bloomberg          |
+| Robin Ricard         | RRD            | BLoomberg          |
+| Yulia Startsev       | YSV            | Mozilla            |
+| Mary Marchini        | MAR            | Netflix            |
+| Istvan Sebestyen     | IS             | Ecma International |
+| Shu-yu Guo           | SYG            | Google             |
+
+
+## Opening, welcome, housekeeping
+Presenter: Aki Braun (AKI)
+
+AKI: (presents slides)
+## Secretary’s Report
+Presenter: Istvan Sebestyen (IS)
+
+- [slides](https://github.com/tc39/Reflector/files/5246401/tc39-2020-041.pdf)
+
+IS: (presents slides). The usual information, about TC39 standards access and download, status of meeting planning and news in Ecma, etc. The only relevant news are that formal liaison with CalConnect not dot done yet due to the incompatibility of the two patent policies (Ecma TC39  = RF and CalConnect = RAND). Suggestion was discussed with CalConnect that CalConnect should establish an “experimental RF patent policy” (takes of course some time), until then CalConnect experts should participate in TC39 work as invited experts in personal capacity accepting the TC39 RF patent policy. 
+
+## ECMA262 Status Updates
+Presenter: Jordan Harband (JHD), Kevin Gibbons (KG)
+
+- [slides](https://j.mp/262editor202009)
+
+JHD: (presents slides)
+
+
+(Re. normative PR slide)
+
+KG: Re. 2094, this is something that we discussed last time where if you do `x = delete x, 1` then you can get into a situation where the implementation's concept of references don't match the spec's concept of references. There are still a lot more of those that we will need to sort out eventually.
+
+SYG: This is the slide that implementers should take note of, to see which normative changes have landed. The PR may get slipped through the cracks. This is a good time to pay attention to it. Once it has been merged, it would be good to prioritize fixes.
+
+JHD: (continues to present slides)
+
+KG: (presents slides)
+
+WH: Thank you for following up on the math contradictions and inconsistencies I raised. Watching the new PRs, I’m still seeing a bit of inconsistent usage of arithmetic and comparisons on real numbers vs IEEE doubles.
+
+KG: PRs or commits?
+
+WH: PRs.
+
+KG: That is true, I am keeping PR 2007 rebased on commits which made it into master but I haven't been worrying about PRs. When it lands, I will rebase the rest of the PRs to update the style to match 2007.
+
+WH: Great! I’ll hold off on pointing out inconsistencies in other PRs until PR 2007 lands. I really appreciate you doing this cleanup!
+
+KG: Thank you for pointing it out! This uncovered a number of places where implementations have diverged.
+
+MF: (presents slides, “GitHub Project: Major Editorial Work”)
+
+
+
+## ECMA402 Status Updates
+Presenter: Shane F. Carr (SFC)
+
+- [slides](https://docs.google.com/presentation/d/1FeyW-QdZqAQ0xvrPacI347gYRuBtZ8NR6lV6n0bca4M/edit?usp=sharing)
+
+SFC: (presents slides)
+
+
+## ECMA404 Status Updates
+Presenter: CM
+
+
+CM: ECMA404 sleeps happily, let’s try not to wake it up.
+
+
+## ECMA TC53 Liaison Report
+Presenter: Peter Hoddie (PHE)
+
+- [slides](https://www.icloud.com/keynote/0_6IXVVSlbeV1Dm2OdEJt-5kQ#tc53_liaison_tc39_-_september_2020)
+
+PHE: (presents slides)
+
+## Updates from the CoC Committee
+Presenter: Jordan Harband (JHD)
+
+
+JHD: (presents CoC updates)
+
+## The last 5 years of Test262, a brief review
+Presenter: LEO
+
+LEO: (presents slides)
+
+RKG: Bravo. Let’s give applause.
+
+(many people give virtual applause over webcam)
+
+## Explicitly specify order of operations in MakeTime
+Presenter: Kevin Gibbons (KG)
+
+- [pull request](https://github.com/tc39/ecma262/pull/2120)
+
+KG: (presents PR)
+
+KG: Questions? Consensus?
+
+(silence)
+
+KG: I will take that as consensus.
+
+### Conclusion/Resolution
+
+Consensus Reached.
+
+## Move __proto__ out of Annex B
+Presenter: Gus Caplan (GCL)
+
+- [pull request](https://github.com/tc39/ecma262/pull/2125)
+
+GCL: (presents PR)
+
+JHD: Annex B represents two things. 1 is web browsers need to do this thing, but others not. that are required for some JS to run. The other thing is things that are “icky”. Something's presence in Annex B is often cited as a reason to pick one approach over another, and that's something we want to preserve. Just marking something as normative optional doesn't do that. It says "this is fine, but it may not be there." I would love to include some way to include this discouragement. I think it would be a loss if the spec implied that these things would be good to use.
+
+GCL: To clarify, your concern is about the spec sending a message to non-implementers, people who use JavaScript?
+
+JHD: Yes, not to implementers, but to practitioners.  
+
+GCL: I don’t know if we care about that, but it is interesting.
+
+JHD: If I had to write an engine and discovered later that i had to implement these optional things anyways, I would be annoyed. Hopefully we can fix that without losing the signalling to users.
+
+GCL: I think the spec is not the appropriate place to be putting our direction to end users. It seems like that's the wrong layering.
+
+JHD: To me it is less about what we should do, but that users do take lessons from the spec.
+In the same way as a lot of these things in Annex B refer to de-facto reality, a lot of people take de-facto direction from the spec and I don't think we should ignore that.
+
+WH: I agree with JHD about “icky”. The spec is used in surprising ways. Did you know that the C++ ISO standard references the ECMAScript spec for its regular expressions? Moving things out of Annex B has the ability to change how C++ regexes work.
+
+BT: Did C++ intend not to adopt Annex B?
+
+GCL: It does reference ES3, so it won’t affect forward momentum.
+
+WH: It would if the C++ committee ever rebases their links.
+
+WH: I'm fine with moving `__proto__` out of Annex B but I do want to point out that moving things out of Annex B in general is much more perilous than some may realize.
+
+MM: We did discuss the “icky” issue at the time when we were laying out the elements of Annex B and put things into different categories. We reached consensus on removing a bunch of things from the main spec. Having a strong enough editorial signal in the main spec to convey the "icky" issue is the right solution there, and consistent with what we've already achieved consensus on. The reason why it is the more appropriate solution, if we leave it in Annex B, there is implementation variation that is allowed. Sometimes you want to allow that. If your only intent is to have all the implementations do an agreed thing, and try to deter the users from using something "icky", then you want to phrase the spec in such a way that implementers can only implement one thing, that is not the Annex B way. I think we can do appropriate signalling in the spec, DE at one point did a style thing for a non-normative note that was sufficiently attention-grabbing. I would not mind seeing words like "Deprecated" in non-normative language in the spec.
+
+GCL: To address this, if we split it into “someone needs to figure out the styling of how to move these into the body,” then this would be the logical normative part of that.
+
+MM: Yes. Normatively it should go into the main spec. There should not be implementor freedom unless we want implementors to have freedom. We should have a strong signal, the evolution of that signal does not need to go through the editorial process.
+
+BFS: There was something interesting I noted, we discussed if it is something required to build a usable JS engine, when we discuss whether it should be normative optional. XS actually ships these methods, I just double-checked. They implemented these for practical compatibility with the existing user code bases. Even if we are to say something is "icky" or deprecated, the reality that we face is that they are not optional. Not widely used, maybe true, but they have enough usage today to cause it to be implemented in at least one engine that doesn't want to implement it. I think these are actually not normative optional, if the ecosystem relies upon them being shipped for compatibility.
+
+BT: PHE wants to clarify on this topic, if no objections I’d like to let him skip.
+
+PHE: On the specific point raised by BFS, he is absolutely correct that XS does implement these functions. The reason why is important. We never needed them until we wanted to pass certain tests in test262.  There is an unexpected dependency in test262 on Annex B. We would be thrilled to take it out.
+
+GCL: You actively want them to be optional?
+
+PHE: Yes. I have no problem with them being normative optional, but I don’t think that devices should be required to carry them around.
+
+JWK: Why do you need to implement in engine if you can manually define in userland? Deno does not implement this, and if we are using a library and it’s broken, I manually define __proto__ to fix the lib.
+
+BFS: Deno does ship with __proto__, but they delete it on purpose.
+
+GCL: For what it's worth, that's the normative optional part here. I don't think that conflicts with anything. It's very clear you do not need to implement __proto__ to be a ??? engine.
+
+SYG: For `__proto__`, it is uncontroversial, everyone thinks it ought to be discouraged. I know we had a lot of discussion about ASI, and remain neutral in the spec language. If we're to set a precedent here, if we go with an "icky" note, this would be the first thing in ECMA-262 that we say is deprecated and discouraged. I’m trying to clarify what we would be agreeing to. It sounds like case-by-case, we would discourage things in the main body, we would need to get consensus that it is a thing that we want to discourage?
+
+JHD: That matches what I'm asking for.
+
+MM: I would certainly that the “icky” designation should require consensus. ASI did not acheive consensus.
+
+GCL: Can we skip past the ickyness and switch directly to the __proto__ business?
+
+BT: 15 minutes left, up to you GCL.
+
+KG: Which __proto__?
+
+GCL: All the methods and syntax.
+
+KG: All the methods and syntax being moved into the main spec but remaining normative optional?
+
+MM: I thought the syntax was already mandatory?
+
+GCL: The syntax is also moved. It is not normative optional.
+
+KG: The only normative change is making syntax mandatory?
+
+GCL: __proto__ is normative optional. __defineGetter__ etc is not optional. The syntax is moved into the main body, it is not optional.
+
+MM: That seems right to me.
+
+JHD: My topic isn’t ickyness, but I can skip the ickyness part.
+
+BT: Take it away.
+
+JHD: BFS made the point that "icky" and "optional" are different things. Should we make everything required except what we can't? Or should we make everything optional except what we have to make required? __proto__ has to be required, but the _defineGetter__ stuff, I’m asking the general question.
+
+MM: I think it’s complicated. My original presentation on moving things out of Annex B goes into some of the tradeoffs. I don’t think there is a single answer; it depends on why we think something may be optional.
+
+GCL My goal is to have as much as possible be required. The only reason __proto__ is not required is because implementations actively get rid of it. Node has an option. deno gets rid of it. I think we should aim for one JS as much as possible.
+
+WH: I don’t think we have consensus on that. That (make as much as possible be required) is an opinion and we have different opinions on that in the committee.
+
+GCL: We still need to review each item on its own merit. I'm not saying we should move the regex stuff in right now, but in general we should be trying to get to a one JS.
+
+MM: The Test262 point, what PHE said was because not implementing them, test262 fails, that is a bug, that needs to be fixed in test262. Normative optional is specific in that it is either clearly absent, or implemented correctly. And therefore being clearly absent should be a passing situation.
+
+LEO: For what it’s worth, everything in Annex B is in a separate folder.
+
+MM: You agree that having something be absent should be a passing condition?
+
+LEO: There is a separate folder in each test for Annex B relating to each feature. Leaving out those tests is the responsibility of the test runner.
+
+MM: The test itself, in testing conformance, if it is normative optional, if it is absent, it should report success.
+
+BT: Can you file a bug on test262?
+
+MM: Yes.
+
+PHE: I want to make sure where we landed. I don’t want to summarize, I don’t know if we have agreed to anything yet.
+
+KG: We have not agreed to anything yet.
+
+MM: Somebody said that __proto__ should be normative optional because of a security concern. That one is surprising to me because we do have Object.setPrototypeOf and Reflect.setPrototypeOf, both of which are required, which provide all the capabilities of __proto__ through other means. I don’t see what security concern __proto__ would raise.
+
+GCL Its not setting the prototype, it’s that it is a property of objects. Lodash had a bug, an interaction with JSON.parse, it would overwrite the prototype if you weren’t careful. It isn’t setting the prototype itself but a domain problem.
+
+MM: Could you put a pointer to that in the notes?
+
+BFS: You can look up papers on prototype pollution.
+
+MM: This is not prototype pollution.
+
+BFS: The easiest way is what GCL said. The difference is between method call and assignment, when you do a JSON.parse, and has a __proto__ property, people will do that as a dynamic access using that as a key. Deep cloing libraries will naively use that __proto__ key and assign something to an object. This replaces the object’s prototype. For example, Node introduced a flag to disable the proto getter and setter, because there are so many notifications of these bugs, because there are so many find, that they are prohibitive to actually fixing the bug.
+
+MM: Thank you, I have a sense of it now.
+
+BFS: As a personal preference, we should move the syntax for __proto__ that is in Annex B into the main body regardless of the methods. You can have two JS source texts that execute differently based on their environments. Because there is wide enough usage it is problematic that we maintain this divergence. There are inconsistencies with JSON.parse. I think that’s fine. I like moving the syntax into the main spec.
+
+KG: Agree on not marking “icky”.
+
+GCL: I wouldn’t even bother marking it as icky, it is just something people use.
+
+BFS: Sounds good that’s all.
+
+KG: Can you list all of the things that we are asking for consensus on?
+
+GCL: The __proto__ accessor, to be normative optional.
+
+KG: Is it also being marked as icky?
+
+GCL: Do we need consensus on that here?
+
+MM: We need consensus on anything in the main spec that is marked as “icky”. We should not assume in migrating things from Annex B into the main spec that Annex B assumes that it is "icky". It does not.
+
+GCL: I’m just gonna list this off. __proto__ accessor will be normative optional and icky, the __define and __lookup {Getter/Setter} methods will be non-optional and “icky”. Do we have consensus on them being optional?
+
+JWK: I agree.
+
+JHD: Is there anyone that wants the define/lookup methods to be required?
+
+GCL: That's what I'm asking. (silence) Seems like no.
+
+GCL: the syntax for __proto__ will be required and will not be icky.
+
+MM: All of that sounds exactly right to me.
+
+DE: I prefer things to be required. I don’t object to leaving it optional, because it already is optional. But it do think things in general should be required. It's good to unify JavaScript and provide more interoperability. I think our role as a standards body is to provide this interoperability. I don’t object to this landing as-is.
+
+GCL: I agree, I could ask the reverse, to see if anyone objects to them being required, but since we already asked for the other one, that seems — I don’t know.
+
+WH: I prefer optional, although it's not a strong preference.
+
+GCL: Seems like we have consensus for optional. Let’s move forward with that?
+
+KG: Can I recap? To make sure we all know what we agree to?
+
+- The __proto__ syntax will be required and not marked as discouraged
+- The __proto__ accessor will be optional and marked as discouraged.
+- The __defineGetter__, __defineSetter__, __lookupGetter__, and __lookupSetter__ will be optional and discouraged.
+
+Note: icky means discouraged
+
+SYG: Given that this is the first time that we are marking these things as “icky”, I would like some acknowledgement that the editor group be given some independence over  ???
+Vs. if you are bootstrapping a greenfield ecosystem you are discouraged from implementing this.
+
+JHD: SYG, this is not the first time we’re marking things as “icky”. There is precedence for that, for example Annex B itself (quotes the beginning of Annex B on the definition of "discouraged") That said, I agree with your request for editorial leeway. I just wanted to clarify.
+
+MM: Being in Annex B, it can be there for a variety of reasons, not everything in there is undesirable, it has to be on a case-by-case basis as we move it.
+
+JHD: I’m not trying to imply that we should mark everything as “icky”.
+
+WH: MM, read the beginning of Annex B. It currently states that everything in there has undesirable characteristics. We can change our minds on some of that, as we move items, but the “icky” designation is there now.
+
+MM: Ok.
+
+### Conclusion/Resolution
+- The __proto__ syntax will be required and not marked as discouraged
+- The __proto__ accessor will be optional and marked as discouraged.
+- The __defineGetter__, __defineSetter__, __lookupGetter__, and __lookupSetter__ will be optional and discouraged.
+
+
+## Align detached buffer semantics with web reality
+Presenter: Ross Kirsling (RKG)
+
+- [pull request](https://github.com/tc39/ecma262/pull/2164)
+
+RKG: (presents PR)
+
+PHE: I don't have a strong position. I remember the GitHub issue. There are 2 issues that pass this: Two implementations, Moddable and ???, both get this right, conforming to the spec. I completely agree that the spec should address web reality. I appreciate the work you and others have done to pin that down. A different way to look at this is that this web reality is another Annex B behavior. The web is looser with enforcing some of the requirements in the spec than the language would prefer. These differences could be put into Annex B as required for web browsers. It would maintain the intent of the specification better.
+
+RKG: That makes sense. My understanding (which may be imperfect) is this has been pretty  consistent in browser-hosted implementations all along; that TC39 inherited the spec’ing out of ArrayBuffer et al. from Khronos during the ES6 era and wanted to make these cases more stringent, but the ship had already sailed in engines. It's just taken this long to be an official web compat issue.
+
+GCN: This should not be in Annex B especially for node because there is ton of code to handle it. It would be more appropriate to do the “icky thing” but I think it should not be added to Annex B.
+
+SYG: I don't disagree with PHE that you can call it out… if you are more interested in interoperating with the existing corpus of code, that's where you might have the option to break. But I also don't think there's a principled reason to prefer the current throwing behavior other than that we wrote it in the spec and that some implementations are following it. So I wouldn’t necessarily even starting with the default position it is icky.
+
+DE: I think it's really great work that RKG did to bring this to the standard. I hope we get consensus on it. I think it's a real improvement. I think building interop should be a core goal of standards. I would be hesitant to create multiple paths. I don't know what "icky" would mean here. This is a code path that's just part of the object operations for this. So I'm not really how marking it would work. If I were able to declare parts of JavaScript icky, I would mark a whole bunch of things, which might be what other people might not agree on. I don't see that as our role.
+
+JHD: from your PR, I definitely see why the delete needs to be changed if they are configurable, … Can you elaborate on why to satisfy those invariants we must make integer indices configurablnone?
+
+RKG: This was brought up by @anba and SYG; it’s needed to avoid breaking an EIM invariant for [[HasProperty]].
+
+JHD: Can you explain the hasProperty change? I'm trying to get my head around the logic.
+
+KG: If a property is not configurable, it must never go away. These go away, so they have to be configurable.
+
+JHD: Go away as in reporting a different value?
+
+RKG: Yeah.
+
+SYG: A question at JSC, in my testing, correct me if I’m wrong, JSC throws and this pr would make it return undefined and false, and be a no-op in sloppy mode?
+
+MM: The set operation returning false is only a no-op in sloppy mode. In strict mode, it causes an assignment to throw.
+
+SYG: So the question to JSC is (???) in aligning with V8 and SpiderMonkey behavior?
+
+RKG: I will say that I’ve already been planning on correcting JSC’s behavior but am waiting for the result of this presentation; I can’t speak on behalf of Apple though.
+
+KM: I don't think it would be a problem.
+
+SYG: I think it the issue that turning an error to a non-error has minimal compat risk. 
+I am willing to add Chrome to be the first do that change.
+
+KM: Compat risk is always a problem.
+
+RPR: At time, conclusion?
+
+RKG: Seems like everyone is onboard?
+
+(silence)
+
+### Conclusion
+
+PR Approved.
+## Specify order of name and length for built-in functions
+Presenter: Kevin Gibbons (KG)
+
+- [pull request](https://github.com/tc39/ecma262/pull/2116)
+
+KG: (presents PR with code example)
+
+KG: I'm asking for consensus that 'length' come before 'name'.
+
+RPR: No-one on the queue, thumbs up.
+
+MM: Bravo for bringing this inconsistency to our attention and resolving it!
+
+GCL: The prototype property was in different order, is that out of scope now?
+
+KG: I'm not specifying the order in which the prototype property would need to be enumerated.
+
+GCL: Ok
+
+MM: Why not?
+
+KG: Because there is no agreement among engines.
+
+RGN: Strongly in favor of this and love the increased consistency.
+
+KG: I might come back with a prototype in a future meeting.
+
+### Conclusion
+
+Consensus.
+
+## 	Arbitrary Strings as export/import names
+Presenter: Bradley Farias (BFS)
+
+- [pull request](https://github.com/tc39/ecma262/pull/2154)
+
+BFS: (presents slides)
+
+WH: Is this the first place in the spec where you check for “valid unicode”? 
+
+BFS: To my knowledge, yes, but there is iteration of code points for a specific operation. The spec doesn't check for isValidUnicode anywhere, but it does iterate code points.
+
+GCL: It does that in string iterators and regular expressions
+
+WH: The notion of valid Unicode is quite fuzzy. Suppose your string begins with a byte-reversed byte order mark. Is that valid Unicode?
+
+BFS: I don’t think byte order mark is a lone surrogate concern...
+
+WH: It's a different "valid unicode" concern. There are things you can do in Unicode strings that are “invalid Unicode” that are not related to surrogates.
+
+BFS: can you do that in a JS string literal?
+
+WH: Yes
+
+BFS: Ok, so they are valid UTF-8
+
+WH: They are their own thing.
+
+BFS: Wasm only supports UTF-8. We could change the operation to be, "isValidUTF8". Seems like what your concern is outside the attempt to get compatibility with Wasm, I have no strong opinion so any option is good.
+
+WH: IsValidUTF8 sounds good to me. It makes explicit what you are checking for. IsStringValidUnicode is too vague.
+
+BFS: Sure, we can rename it.
+
+KG: The sequence does not contain unpaired surrogates
+
+WH: A 16-bit code point sequence contains no unpaired surrogates if and only if it can be represented as UTF-8.
+
+MM: UTF-8 is not a concept that appears anywhere else in JS, JS mostly refers to UTF-16, there is no problem with UTF-8 but is the operational implication of that with regard to UTF-16 the same as saying valid UTF-8?
+
+WH: Yes.
+
+MM: So, I would state it in terms of no unpaired surrogate pairs.
+
+BFS: more nuanced than that, it is about how Wasm represent things
+
+MM: I understand the motivation. Is the implication of being able to translate to valid utf-8, is the implication on a utf-16 encoding “no unpaired surrogates”. If so, it should be “no unpaired surrogates”.
+
+JHD: MM, there are plenty of references to the UTF-8 concept in the spec: valid utf8 codepoints, JSON stringify, etc ...
+
+MM: I didn’t know that; thanks!
+
+BFS: We can also change it in some way that we - I don’t like the idea of phrasing it, that it doesn’t contain any lone surrogates explicitly, although to the most technical letter what it is doing. If we name it specifically that, it won’t get updated to valid problems in the future, 
+If there is a problem found with this method, that basically asserts that it does return code points that are complete, then we wouldn't get that if it states "doesn't contain lone surrogates".
+
+MM: I have no objection to either way of phrasing it, I prefer the lone surrogate but if you prefer UTF-8, I am ok with this.
+
+YSV: There is no objection from our side, but to JHD’s point, We’d like to prefer UTF-16 wherever possible unless there is a conscious decision. In this case UTF-8 does make sense due to the WASM case. 
+
+DE: I think we’ve been talking about UTF8/16 for a while, we should focus on editorial issues on the PR. I don’t think we should focus on UTF8/16, I like the feature and it makes sense. I'm the champion on the WebAssembly side of the ESM integration. I think it's good that we have this field in. It makes sense that we only import or export valid Unicode code point strings, as this does.
+
+AKI: Queue empty. BFS? 
+
+BFS: I would like to ask for consensus, remaining editorial issues to be discussed with people on it.
+
+DE: I want to make a suggestion with the consensus. I would like that we wait for Test262 as well as 1-2 implementations to prove out the concepts. This is something I've been meaning to make a process document PR for a while. I think it's important to do something similar to the Stage 4 requirements. Would people have problems with adding this to this PR and array buffer detached semantics and have a follow up with the process?
+
+BFS: Does that mean I would come back for consensus to land it?
+
+DE: It would be handled only on the issue tracker.
+
+MM: +1
+
+SFC: +1
+
+JHD: DE has already asked in the past for a general process for this, and we agreed we’d apply it case by case. This makes sense in the case of that PR, so I think this is a good idea.
+
+DE: When I proposed that in general, we adopted the rule that normative PRs need Test262 tests. An implementation would help us iron out this PR better.
+
+GCL: Engine262 has this implemented already.
+
+### Conclusion
+
+Approved, pending the Test262 and implementations.
+
+## Numeric literal suffixes update: separate namespace version
+Presenter: Daniel Ehrenberg (DE)
+
+- [proposal](https://github.com/tc39/proposal-extended-numeric-literals)
+- [slides](https://docs.google.com/presentation/d/1lD2NN0I3HFhTqFCtz7WTXEsbbxno4VqfUOUwZgrGHRs/edit#slide=id.p)
+
+DE: (presents slides)
+
+WH: There are other letters you should exclude like `p`; ieee doubles can use them for exponents.
+
+DE: I thought it was `e`.
+
+WH: `e` is used for decimal exponents; `p` is used for binary exponents.
+
+DE: Is it part of JS syntax?
+
+WH: Not right now, but we could add it in the future.
+
+DE: Is there anything else we need to add besides `p`?
+
+WH: The exclude list is getting rather large. `a` through `f`, …
+
+JHX: This is a simple question, whether we follow 0x, or just like that, will `cm` work grammatically?
+
+DE: Yeah; `1cm` doesn't work. The CSS units will simply not all work.
+
+JHX: That seems like a problem. There are many CSS units; not only `cm`, but also `deg` and some others. I think it doesn't match all the use cases.
+
+DE: I guess for those use cases, they need to put something before them suc as $ or another letter. I agree it is a limitation.
+
+GCL: The parsing optimization you mentioned sounds interesting but not applicable in some cases because of, like, if you used a suffix inside of a function, and then below the function you used the suffix, the order might not line up.
+
+DE: To be clear, the opt I’m talking about are for built-in suffixes, the user-defined ones are evaluated when they are first encountered.
+
+GCL: Okay, yeah, that makes sense.
+
+GCL: I really dislike using a different namespace. You mentioned that it might class with loop variables, but I actively do not want to read or write code where some of the "i"s are variables and others are numeric functions. We really should use the same namespace here. I’ll even throw out the `@` symbol because this is decorating a number.
+
+DE: I proposed the `@` symbol previously and people told me not to mix decorators with this. If we make them the same namespace, we need the underscore. Part of it is overlap, part of it is optimization cases where we can partially evaluate the for built in suffixes, they would have to first resolve the namespace to check if they are shadowed locally.
+
+GCL: Yeah, but those all deoptimize code anyway. It's not a new thing.
+
+DE: `with` and `eval` don't globally “deoptimize”. They cause localized problems. We shouldn’t make the optimization of numeric literals be fragile and context-dependent.
+
+MM: You're not solving that with a separate NS, you can still have shadowing in a separate namespace.
+
+DE: I didn't explain the invariable clearly. Neither `eval` nor `with` would leak an entry in this new suffix namespace.
+
+MM: It wouldn't publish it externally, though.
+
+DE: For `with`, there is no way it can participate in the suffix name space. If a suffix is declared in an `eval`, it is scoped the inside of that eval, like a `let` declaration, not like sloppy mode `var`.
+
+MM: The var and the stopping mode leaking out is what I meant by "publish". On the shadowing issue, it would still shadow across a direct eval.
+
+DE: if you have an eval with a literal suffix in a direct eval then it can only shadow within that eval, not leak/publish outside of it.
+
+WH: MM, what do you mean by "shadow"? If I direct-eval inside a block and suffix `m` is defined in that block, then the eval would pick up the numeric suffix?
+
+MM: that is what I meant. The shadowing that I had in mind, is not the problem, the eval leak/publish, that doesn’t seem to be a problem in that case.
+
+WH: So we’re concerned about things leaking inward into eval?
+
+MM: The leaking inward is what I was initially concerned about, but there's no problem there.
+
+GCL: I don't find the `with` and `eval` cases compelling or motivating enough. I don't think we should be optimizing for "make code fast in sloppy constructs".
+
+DE: more about engines to be able to keep their structures. Literals should also be predictable, for developers, that you can’t shadow.
+
+MM: Any developer who wants to understand their code should stick to strict mode.
+
+DE:  I see two options: (1) making a separate namespace, with no prefix, or (2) making the underscore an explicit separation. I don’t think we can make it so that it only refers to the lexical scope with no prefix like `_`. I was laying motivations for why those were the two options.
+
+MM: I very much prefer the polyfillable principle: that whatever new suffixes for built-in types going forward, the things you can do at the user level can look like that. It's a good design principle that the mechanisms available to language designers, as much as that power can be given to the user can be good, that doesn’t mean bare m can’t be the suffix could be ??? instead of _m. So, as this discussion has proceeded, I'm leaning toward the underbar, even though I wasn't used to. That way, we solve the need for the separate namespace without creating a separate namespace mechanism. I'd say that new builtins after BigInt all have the same preceding underbar.
+
+DE: I’m OK with that possibility as well.
+
+CM: orthogonal to that discussion: simply have the lexical analysis scan a literal until it encounters a non-numeric character, then treat whatever follows as the suffix; some use cases might not care about hexadecimal so they could have suffixes beginning with A-F with no problem.
+
+DE: It sounds like you're proposing the thing I was discussing before, which is that the "m" would be looked at in a lexical scope. That would make it such that BigInt can't use the optimization where the compiler can map it.
+
+CM: this is unrelated to the scoping question, we are talking about lexical analysis of numbers.
+
+DE: So, I would be fine with that alternative. I'm worried it would be harder for people to parse. Maybe we could ban "e" just in decimal literals. This is the first time I've heard of "p", so I don't know in which situations it is used.
+
+CM: I don’t know that I agree that the complexity of this proposal carries its own weight, but the question of lexical analysis of a broader range of suffixes seems like a problem we can solve.
+
+MF: I don't think this is worth it, especially with all the caveats and given tagged templates exist for exactly this sort of thing. I don't think it brings much additional value, besides static checks you can do on it. Tagged templates solve polyfillability, since it is all in userspace. If people want analyzability on it they could have their editor check for tagged templates or something like this or trying to use different namespaces for naming of the suffix, I just don't think it's worth it, especially given how expensive I see syntax being.
+
+DE: Do you recommend for bigdecimal, we use a tagged template literal? That would be different from BigInt
+
+MF: Yes.
+
+DE: What do others think?
+
+KG: I agree with MF.
+
+WH: I wouldn't want to use tagged template literals for that.
+
+MF: can you explain?
+
+WH: You asked what others think. Let’s not dwell on that and continue with the queue first — we only have a couple minutes left.
+
+YSV: How significant is the user need for this level of configurability and generality? It's clear that there are a couple forms it can take. If you could hypothetically use any character, how frequently can this be used? I see that this solves a problem with decimal literals, but I can see how this wouldn't have much uptick, and then we end up specifying something that doesn't end up being used much. How frequently would this be used? I see the advantage for decimal, but I have a hard time justifying the user level customization. I can see for react or the dollar sign as a use case.
+
+DE: I don’t have to add any further as you seem to understand the use case here. The dollar sign is about a literal of the decimal type. You can do that with a tagged template literal, etc. WH's proposal from a while ago used a suffix I believe. MM challenged me to find something that generalizes to the whole language so that is the exercise I’m doing here. There are 4 things we could do: one is to switch to tagged template literals; one is to not add decimal; one is to do one of the proposals I presented on; and one is to special-case the "d" suffix to build in decimal only, like we did for BigInt. I think the decimal itself would be very very useful
+
+WH: A couple quick observations: Excluding a bunch of different letters `a`, `b`, `c`, `d`, `e`, `f`, `o`, `p`, `x` bothers me because it makes prefixes irregular. Earlier in this discussion folks stated that using a `_` can fix it. How?
+
+DE: I don’t know who made the claim. There would be problems even with an underscore.
+
+WH: Second observation: I do very much like the separate namespace. For example, a good use case of this would be representing complex numbers, `3+4i` shouldn't conflict with an index variable `i`.  I think of the `i` in the number more as syntax than a variable name, just like I don’t think of the `e` in `3e-4` as a variable.
+
+## Need another stage 3 reviewer for iterator helpers
+Presenter: Michael Ficarra (MF)
+
+No slides
+
+MF: Need another review for iterator helpers, so we can be prepared for advancement at the next meeting. Would anyone like to volunteer for review? RGN is the one existing reviewer.
+
+GCL: The proposal is on the larger side right now, but it might get smaller.
+
+YSV: We’ve been pretty involved in the proposal, but if that wouldn’t be a problem, I can propose JTO or myself for review.
+
+MF: If I had RGN and either you or JTO, that would be good for me.
+
+MM: Why would that be a problem?
+
+YSV: Because we've been heavily involved in writing the spec text.
+
+MM: I don't think that's a problem.
+
+JHD: in general authors reviewing what they wrote can be a problem but here it is fine.
+
+### Conclusion/Resolution
+
+YSV/JTO will review
+
+## Withdrawing TypedArray stride
+Presenter: Shu-yu Guo (SYG)
+
+- [proposal](https://github.com/tc39/proposal-typedarray-stride)
+
+SYG: The feedback from engines is that this would slow down the index operator, and for the more complex use cases, the proposal was not expressive enough, in particular things doing with graphics programming. Beyond just reading RGBA channels, this itself wasn’t good enough for other graphics use cases like reading more complex structs. So, with all of that, I would like to withdraw this proposal. That's not to close off future research, but it seems that the general space needs something more expressive, like struct overlays.
+
+AKI: You already answered my question, is this still a problem to be solved? The answer seems to be yes.
+
+SYG: Archive the proposal repo? 
+
+AKI: Archive and remove it from the proposals listing.
+
+JHD: Already got that.
+### Conclusion/Resolution
+
+Proposal will be withdrawn
+
+
+
+## F.p.bind with infinite-length functions
+Presenter: Kevin Gibbons (KG)
+
+- [proposal](https://github.com/tc39/ecma262/issues/2170)
+
+KG: (presents PR)
+
+JRL: I’m not an implementer but I should caution with it, objects have a hidden class (?). I'm curious if, if we set length to be Infinity, which is a float, if this will have ramifications.
+
+KG: I have no idea! Do any implementers have any concerns about this?
+
+GCL: I see an optimization if you're accessing the length property.
+
+SYG: Checking, but can’t answer in 5mins
+
+YSV: I will check for SpiderMonkey
+
+KM: For JSC, with high probability, since this is a named index property, we don't do any int32 optimizations here. You might get arithmetic optimizations here. I don’t think anybody is using length for anything here. THis is all based on the lexical code, length is nice for users but has no real meaning for engine.
+
+MM: I saw the spec text again, I withdraw that question. I'm in favor of the correct answer being Infinity.
+
+KG: This does not in fact require a change in JSC, because they changed this recently, apparently. Someone from JSC expressed a slight preference to clamp to Number.MAX_SAFE_INTEGER. I don't like that though, mostly because SM/V8 use infinity.
+
+MM: What would the spec text say, what happens for other problematic values besides infinity
+
+KG: Other problematic values are wrapped up by toInteger. That's a fascinating operation that given anything anything that coerces to a number (ToInteger) without side effects; it returns 0 for NaN and -0 (?); the nearest integral number rounding toward 0 for any finite number; and returns the respective infinity for infinities. So the other weird values are already handled by toInteger.
+That is the only case you need to deal with here (showing up spec patch).
+
+MM: I have mild distaste for adding another branch to the spec. I was hoping that you had phrasing in mind that would not add a separate condition.
+
+KG: Unfortunately no; everywhere toInteger is used, it must check for infinity. I have renamed it to ToIntegerOrInfinity to take up on that case. 
+
+MM: Ok, yes
+
+KG: For what it's worth, it's not going to lead to a branch in most implementations.
+
+AKI: Nothing left on the queue.
+
+KG: I would like to ask for a consensus for infinity as a correct answer to this case.
+
+### Conclusion
+
+Consensus. We will use Infinity.
+
+## Date arithmetic
+Presenter: Kevin Gibbons (KG)
+
+- [slides](https://docs.google.com/presentation/d/1gePsNmlP2u0pYXm0LWO3d7eM4Q_y5Ozx0qXN1zWOv58/)
+
+KG: (presents slides)
+
+SYG: Yes
+
+WH: What do implementations do?
+
+KG: Implementations implement this operation using floating point, with the exception of small engines like QuickJS.
+
+WH: You mentioned that they do in this particular date computation. Do they do that for all of the affected date computations?
+
+KG: I glanced through the code, and I think yes but I don’t know
+
+YSV: I know we use IEEE arithmetic, I don’t know for others, for SM, we use ieee everywhere.
+
+SFC: What was the engine that uses int64 math?
+
+KG: QuickJS. Fabrice did his date arithmetic on 64-bits integer
+
+PFC: If you had to pick an option for Temporal, without regard to existing implementations, would you settle on using IEEE arithmetic? Or use BigInt?
+
+KG: I would say Int64. That way you can be precise without paying a cost. Aesthetically Int64 won’t give you errors for the things you care about.
+
+PFC: OK, thanks!
+
+KG: So that's consensus on floating-point semantics.
+
+KG: Bonus round: NaN. If people want to reject because we need more time for review, they can. It is kind of important as it holds off the PR with Date arithmetic in the spec.
+
+KG: (presents slides, starting “Bonus round: NaN”) Asking for SM semantics.
+
+JHD: +1 for either "check none" or "check all", preference for "check all".
+V8 seems to do something bizarre to me. Either JSC or SM behavior seems fine.
+
+WH: +1
+
+DE: I don't think we should get consensus on things that were added the same day.
+
+JHD: Our policy is that anything can be added at any time, but proposals can be prevented from advancement.
+
+DE: I'm invoking that.
+
+KG: The spec text is incoherent.
+
+DE: The incoherency situation, you are making a normative change.
+
+KG: That is true.
+
+JHD 10 days deadline doesn’t apply to normative changes...
+
+DE: I know that our deadline says case-by-case, so I’m invoking the clause that says it should be there.
+
+### Conclusion
+
+Consensus on part 1: IEEE arithmetic in Dates
+
+No consensus on part 2 on grounds of late addition to the agenda.
+
+## Move outreach groups to the TC39 org, like incubator calls?
+Presenter: Daniel Ehrenberg (DE)
+
+- [outreach groups](https://github.com/js-outreach/js-outreach-groups/)
+- [slides](https://docs.google.com/presentation/d/1Gqz6Y7ymNhWzKAn09R96xx1nYV6HwiaJVMl5ral0sK0/edit)
+
+DE: (presents slide)
+
+WH: What is the IP policy for these?
+
+DE: These don't produce IP. People talk about ideas, but if people produce IP, they do so in the context of normal proposals. Somebody making a PR on GitHub against the proposal and that would be when they contribute IP, it goes through our normal GitHub process. At that point, you sign the non-contributor IP agreement.
+
+JHD: part of the concern around these when brought up. Incubator calls in general, there might be binding decisions that might be done, we know it’s not the case with outreach groups, how would we resolve that?
+
+DE: It’s hard for me to understand how this would happen. Even if a delegate raises a concern, there is no timing constraint to make a decision. If you have a champion group meeting or 8 people talking out of committee, they wouldn’t have any weight there. In incubator group meetings, attendees don’t have any right to make decisions; champion groups as well.
+
+JHD: What I am lightly concerned about is the folks who chose to participate, having their expectations set correctly. The audiences of these people, some of whom have large audiences, not getting a mistaken impression of the effect the outreach groups have.
+
+DE: For the outreach groups, I've written a doc that sets the ground rules, at https://github.com/tc39/js-outreach-groups/blob/master/README.md
+
+JHD: that seems like a good answer for the participants, I have seen people in these groups put something in their twitter or linkedin bios etc. claiming authority linked to TC39 because they are in outreach groups. I have also seen uninformed people assume that these people have status. People have asked questions in IRC about outreach groups and how to obtain this “power”. Obviously it's easy to correct cases that are brought up, but there is even already an overinflated sense of power that participation in these groups does not concur. There is already a mistaken/overinflated sense of power for participation in these groups. I’m not saying we shouldn’t transfer them in, just bringing it up.
+
+DE: I made it clear in the outreach group readme that anyone can write an email to be included in this. Ultimately, I think there are lots of misunderstandings that people have. Even members of TC39 talking informally can create the wrong impression. Members of TC39 already say harmful things such as saying that a decision has been made when it hasn’t been. It’s not unique to outreach groups, it is already an issue.
+
+AKI: I love this idea. I'm a supporter of the outreach groups. I support bringing them into TC39 since they are part of what we do. People on the internet trumpeting they have power that they don't have is a non-issue. Yes there is a possibility someone is going to make our job harder because they said they represent TC39 but actually do not. But this is not a huge issue and it is manageable as it does not happen often. I think that getting the information we get from educators and framework authors, and disseminating authors, and asking what you want, is so valuable, and I'm a huge supporter of bringing these into the TC39 org. I don't think there's an issue with the appearance of decision-making or authority where there is none.
+
+LEO: I have one followup with DE after it. On IP: use LICENSE file on any new repos in the org. It's been a consistent and simple solution among Open Source projects on github. Add-in to license file. It is simple, I’ll follow up.
+
+DE: I don't think a LICENSE file is sufficient for TC39's work. That covers copyright of notes. But it doesn't cover patent claims. That is why they should sign the non-contributor form that should be mandatory. If the person uploading the notes to the repo would be implicitly contributing those notes according to the license--I don’t think this makes sense for this repo, since they didn’t even have copyright over the utterances in the meeting in the first place.
+
+LEO: Ok, I can follow up.
+
+YSV: Let's wrap up. DE wants to move these calls into the TC39 org. What is the committee's feeling on that?
+
+MM(?): Positive.
+
+### Conclusion
+
+The outreach calls will be moved into the TC39 org.

--- a/meetings/2020-09/sept-21.md
+++ b/meetings/2020-09/sept-21.md
@@ -357,7 +357,7 @@ SYG: A question at JSC, in my testing, correct me if I’m wrong, JSC throws and
 
 MM: The set operation returning false is only a no-op in sloppy mode. In strict mode, it causes an assignment to throw.
 
-SYG: So the question to JSC is (???) in aligning with V8 and SpiderMonkey behavior?
+SYG: So the question to JSC is are you interested in aligning with V8 and SpiderMonkey behavior?
 
 RKG: I will say that I’ve already been planning on correcting JSC’s behavior but am waiting for the result of this presentation; I can’t speak on behalf of Apple though.
 

--- a/meetings/2020-09/sept-22.md
+++ b/meetings/2020-09/sept-22.md
@@ -1,0 +1,728 @@
+# September 22, 2020 Meeting Notes
+-----
+
+**In-person attendees:**  
+
+**Remote attendees:** 
+| Name                 | Abbreviation   | Organization       |
+| -------------------- | -------------- | ------------------ |
+| Waldemar Horwat      | WH             | Google             |
+| Frank Yung-Fong Tang | FYT            | Google             |
+| Shane F. Carr        | SFC            | Google             |
+| Devin Rousso         | DRO            | Apple              |
+| Caio Lima            | CLA            | Igalia             |
+| Kris Kowal           | KKL            | Agoric             |
+| Mark S. Miller       | MM             | Agoric             |
+| Chip Morningstar     | CM             | Agoric             |
+| Mark Cohen           | MPC            | PayPal             |
+| Jason Orendorff      | JTO            | Mozilla            |
+| Shruti Kapoor        | SRK            | PayPal             |
+| SongYang Pu          | SYP            | Alibaba            |
+| Chengzhong Wu        | CZW            | Alibaba            |
+| Ross Kirsling        | RKG            | Sony               |
+| Sven Sauleau         | SSA            | Babel              |
+| Jordan Harband       | JHD            | Invited Expert     |
+| Istvan Sebestyen     | IS             | Ecma International |
+| Dave Poole           | DMP            | Apple              |
+| Devin Rousso         | DRO            | Apple              |
+| Michael Saboff       | MLS            | Apple              |
+| Keith Miller         | KM             | Apple              |
+| Bradford C. Smith    | BSH            | Google             |
+| Jem Young    		   | JZY            | Netflix            |
+| Philip Chimento      | PFC            | Igalia             |
+| Richard Gibson       | RGN            | OpenJS Foundation  |
+| Robin Ricard         | RRD            | Bloomberg          |
+| Jack Works           | JWK            | Sujitech           |
+| Mary Marchini        | MAR            | Netflix            |
+| Justin Ridgewell     | JRL            | Google             |
+| Yulia Startsev       | YSV            | Mozilla            |
+| Pieter Ouwerkerk     | POK            | RunKit             |
+| Shu-yu Guo           | SYG            | Google             |
+
+
+
+
+
+## Intl.DisplayNames for Stage 4
+Presenter: Frank Yung-Fong Tang (FYT)
+
+- [proposal](https://github.com/tc39/proposal-intl-displaynames)
+- [slides](https://docs.google.com/presentation/d/1SicCmt1bo4jyMTvAUiumCBW2ZqUh_-a18xrTO9nqG7U)
+- [pr](https://github.com/tc39/ecma402/pull/502)
+
+FYT: (presents slides)
+
+SFC: I just wanted to acknowledge all the work that FYT has put into this proposal over the last four years, all the way to stage 4, including the tests, to fulfill this very important user needs. I hope we can advance to stage 4.
+
+MBS: The queue is empty.
+
+FYT: Can we reach consensus?
+
+[silence]
+
+MBS: I’m not hearing any objections, so congratulations on stage 4!
+
+### Conclusion/Resolution
+- Stage 4!
+
+
+## .item() for Stage 3
+Presenter: Shu-yu Guo (SYG)
+
+- [proposal](https://github.com/tc39/proposal-item-method)
+- [slides](https://docs.google.com/presentation/d/1Jk5AE1OEkuvN-pYlKsdppB199VdWL1nCZCOC0JJ8a0c)
+
+SYG: (presents slides)
+
+KG: We should not have String.prototype.item. SYG has already gone over the reasons why, but I want to characterize the risks of each path. The bad thing that happens if you leave `String.prototype.item` out of the language, a programmer reaches for it, finds out it’s not there, and then works around it, perhaps reaching for `slice`. It might also be that there is a reason it is left out, which leads them to do the thing they want to do, which is by code point. The risk to putting it in with code unit semantics, The risk is people will write something that works for them, because they’re an English speaker, and then they won’t write tests for other unicode characters (ex. Chinese). It’s very easy to ship a bug to production that harms people who don’t share your native language. That is a much more serious harm, than the harm that comes from having to reach for a different method.
+
+BFS: I’m curious if you feel that this problem is already kind of a lost cause due to existing methods operating on code units. Is this a hill that’s worth making a stand for?
+
+SYG: Are you asking me or KG?
+
+BFS: KG, and why?
+
+KG: I agree that this is a problem in the language. Adding new methods, which are things that people want to reach for but isn’t there -- I am opposed to adding things for code units. If we didn’t think that this was going to help anyone, if we didn’t think anyone was going to reach for this, then we wouldn’t be adding it. But we are adding it, which is because people will reach for it, but it does the wrong thing, it doesn't actually do the thing that people want, it does something slightly different.
+
+BFS: If it did have the behavior that it currently, as SYG presented, does not have - if it actually did grab a full code point always, would you still say no?
+
+KG: I don’t think item would be the correct name for that method. I don’t think that there should be anything called item. The fact is that there are different notions of index in a string. I am more in favor of adding a separate method that does code points than I am any method that does code units.
+
+BFS: Ok. That's all.
+
+JTO: slice has a lot of use cases that are correct regardless of the code unit distinction. If you do a regex search ,and do offsets off of that, and do a slice, it will be correct because you will get a range that corresponds to characters.
+
+JRL: I’m disagreeing with what KG says and agreeing with what SYG says. We should just add it. To what KG says about we’d be adding the ability for them to ship a bug, they’re already shipping a bug. ???
+
+JHD: I think that item is important, I think the concerns KG is describing - not everything in strings is prose. Strings are used for enums, bitmasks where code units are what you want. On top of that, code points aren’t what you want most of the time; sometimes you want grapheme clusters. If you grab by code points, you’re going to be wrong sometimes. The user wanted a rainbow flag and you gave them a white flag with a rainbow after it.I think that the consistency between indexable strings and arrays is important. Using slice creates an entirely new string -- I have no idea if that has performance implications but certainly seems wasteful. Without this inconsistency I think it is important to have them all, in the same way that they have slice.
+
+WH: I would like us to adopt the simplest solution which is to include `.item`. I find the arguments that we shouldn’t include it completely unpersuasive because iterating by code points is not particularly useful either. It gets lots of things like country flag emojis wrong, which are composed of multiple code points with an ISO encoding of the country’s name abbreviation. The key thing is that I don’t want to have to remember which things have slice vs item vs indexing. Those should all come together. Iteration by code units is the best iteration that we have, let’s make it work.
+
+KG: To be clear I am not proposing that it should have code point semantics. I am saying that code unit semantics is sufficiently bad that we shouldn’t add it.
+
+WH: I disagree with that. I think that code unit semantics are the best semantics we have, and we should make that work.
+
+KG: Even if they are best, that doesn’t mean they’re good enough.
+
+WH: But, there has to be a way to index over strings.
+
+KG: That’s the iteration that strings have, they are by code points.
+
+
+JTO: The committee already addressed this: the iteration on strings is by code point, not code unit. I was actually persuaded to not to String.p.item by SYG’s slide. The team consensus was that everyone would be confused by what we do. But the benefit - I don’t understand what the benefit is of doing this. We should not be in the business of facilitating bugs because users already don’t understand.
+
+SYG: In the interest of time, can we drop the code point vs code unit thing? I am presenting either code units or no String.prototype.item.
+
+JHX: Let’s split String.p.item to another proposal.
+
+SYG: I am ok with that. Let’s talk about blocking concerns. I heard JHD say that he would block if String.p.item was left out?
+
+JHD: I implied that; I did not commit to it.
+
+WH: I share your concern.
+
+SYG: If KG and the folks that think code unit indexing would similarly block if it were there, It seems to be that it’s not a thing I can design around to satisfy both camps. It seems to be a pretty hard choice. Is it true that KG, would you block if it were included to use code unit indexing?
+
+KG: Not if I am the only one with this opinion.
+
+MPC: I share your opinion KG.
+
+SYG: What I will do is ask for Stage 3 for the original plan, which is that String.prototype.item would be included to have UTF-16 code unit indexing. Then if that were blocked, I would like some actionable feedback from either camp as to how I could move to stage 3 for the thing I actually care about, which is Array.prototype.item. Can I get Stage 3 for all the indexables having prototype.item? The editors have signed off for editorial reviews.
+
+RGN: I just did it just before the discussion and signed off on non-blocking commentary on String.
+
+WH: I approve.
+
+KG: Not gonna block, but I think this is a bad idea. I think this is a harm to users of the web.
+
+MF: Is there a better way to get the feeling of the whole room? I don’t want it to cause the whole proposal to fail, but I also really don’t want to have String.prototype.item.
+
+MM: I’m in favor of the proposal as stated because it’s more consistent. I think with the indexing badly issue - I think Strings are already so deep into that, that denying `.item` isn’t going to accomplish anything.
+
+SYG: For what it is worth, I don’t disagree with your concern. I think it is a fine rope to walk.
+
+MBS: Time is up.
+
+SYG: It isn’t a unanimous glowing consensus, but it sounds like we have consensus.
+
+MBS: I’m not hearing any blocks so I think we can call this stage 3.
+
+### Conclusion/Resolution
+- Stage 3 including String.prototype.item with code unit indexing.
+
+
+## Numeric literal suffixes - continued
+Presenter: Daniel Ehrenberg (DE)
+
+- [proposal](https://github.com/tc39/proposal-extended-numeric-literals)
+- [slides](https://docs.google.com/presentation/d/1lD2NN0I3HFhTqFCtz7WTXEsbbxno4VqfUOUwZgrGHRs/edit#slide=id.p)
+
+DE: (presents last slide, “Summary of feedback”)
+
+Should we have this syntax at all?
+Waldemar: Yes, a requirement for Decimal
+Michael F: Better to use template strings
+Should we use a separate namespace, or lexical scope with _?
+Waldemar: Separate namespace seems fine
+Mark: Lexical scope with _ preferred, but the separate namespace is well-formed
+Some others: Separate namespace is not acceptable
+Is it important to have this feature generalized for user definition?
+Mark: Yes, a requirement for Decimal
+Yulia: Asking if the value is sufficient
+Is it acceptable to omit so many identifier start characters?
+Waldemar: This might be too restrictive and bad for future-proofing
+Chip: Permit more identifiers if you're not in a hex literal?
+My feeling: Decimal is sufficiently important for JS developers that we should work through these issues one way or the other
+
+WH: This is a tough design area. You recorded my position as “being fine” with a separate namespace, but it’s actually stronger than that. I think that a separate namespace is pretty much essential, otherwise you get too many conflicts with accidentally captured variable names, especially if you want to use commonly-used index names like `i`, `n`, or `in` which is a keyword. Consistency with existing names of units and such also makes it bothersome to forbid various identifier start characters. I feel that a separate namespace is pretty much essential here.
+
+DE: Is it fair to say that we have these conflicting requirements from TC39 members?
+
+WH: Yes. And the slide you’re showing is a great summary of them.
+
+DE: Thank you everybody for giving this consideration and extra time.
+## Import Assertions for Stage 3
+Presenters: Sven Sauleau (SSA), Dan Clark (DDC)
+
+- [proposal](https://github.com/tc39/proposal-import-assertions)
+- [slides](https://docs.google.com/presentation/d/1RuWMkNAatIZ6lhcdslD8cUD-zntioptqH1-hTbVlhzg)
+
+SSA, DDC: (presents slides)
+
+JHD: The risk of relaxed constraints -- in node, in the modules working group, this is referred to as the “dual module hazard”. Having two instances of a module doesn’t matter if it’s something pure or immutable. But if it’s something stateful, or something where its identity matters, like React, ember, all those frameworks, or a caching module, then you can actually get production bugs from having two copies of the module. I prefer alternative 1, there have been a lot of conversations around this constraint. Effectively, the only time a relaxed constraint would be useful on the web, is when you have “server hijinks” where the server returns different response for the same “URL”. And then separately, when you have some sort of race condition where two of them come in at the same time. It’s circumstances like that which I find edge-case-y. The web is not intending to violate the spirit of this constraint, they will maximally reuse the same instance. I’m content with alternative 1 or 2, either way with the strongly worded editorial note.
+
+MBS: I’m not sure that this is really equivalent to the dual-specifier hazard that we’re having in node. They’re referring to two different instances in the cache, which I don’t see as being entirely equivalent to what we’re talking about here. These would be different cache keys based on the assertion - you might have two instances, but that’s not too different from what we already allow. So I just wanted to clarify that for me, I don’t see this as equivalent.
+
+GCL: I might have missed this, but I’m curious why HTML needs to use the assertions as part of the cache entry?
+
+DDC: The main thing is that they have this set of properties that they want, and their existing cache machinery is the least risky way to satisfy those properties. For example, the big one that made sense to me was if I import foo with type bar and that type is wrong, it shouldn’t block a different import statement from importing with the correct type and having that succeed. There are other ways that you could make that happen - one alternative that we tried was having—when a module was fetched and it came back with a valid mime type, you keep that in the module map but you don’t interpret it until you get a mime time and an assertion type match. There were some corner cases around that, and we made something work but there was pushback—there have been bugs in the past, and they were just wary of solving it in a new way when they have what they already see as a ???.
+
+GCL: One of the design goals of ESM, as I understand it, is that invalid module graphs should not complete, they are invalid. That sounds like to me that they want to work around that? This sounds like something we don’t want.
+
+DDC: I think this was — when you have two different graphs in the same domain, like two root script type=modules in the same domain, I might have one of them contain bad imports, and the other contains bad imports. You want the good one to execute.
+
+GCL: I guess that could - if they’re separate, I’m not an expert on how HTML works, but I would imagine that script type=module would behave similarly to two dynamic import expressions? One could resolve and the other could reject? Maybe I’m just missing something.
+
+DDC: I’m still trying to think. If anyone remembers this scenario better please jump in.
+
+BFS: I can try to explain it. In HTML they have the module map data structure that’s shared across domains (on the settings object) but within a single frame. When you specify two specifiers, the resulting response URL can be the same but they have different cache keys in the module map. An example of this is if you do an HTTP redirect, you can have an initial cache key, and it will be the ???. That could be A, and it points to B, and you could have a separate instance that directly imports B. And if you do that, you would end up with two entries in your module map. In the same case here, they’re trying to reuse the same edge cases with ??? by instead of adding infrastructure outside the module map via the assertions, they would just want to keep it in the same place. There is a computed index in one place, instead of a computed index, it is effectively two indexes into the module map structure. An alternative change would be much more comprehensive. Having a two tiered index means that there is the possibility of having two types of a single URL, so you can have ? effectively as part of the cache.
+
+GCL: If these are separate module graphs, the web has its own higher-up cache, within the context of the specification, the only concern I have is the actual module graphs that we create. So if that’s not what is being offended, then I don’t have a problem.
+
+DE: I think it would meet that constraint, but to give another part of the flavor for why the tighter constraint is hard to meet, we had earlier versions of the HTML integration PR that were attempting to meet the stronger constraint, where it would fetch the module, and if the assertion failed, the module map just wouldn’t store anything at all. That violated a different constraint where we avoided redundant fetches. There was worry that by trying to meet this really high bar, it would create extra complexity in the module map.
+A separate case that’s kind of analogous to import assertions would be, if you have a URL with a fragment (e.g., “https://foo.com#bar”), that also forms a separate module map entry (compared to “https://foo.com#baz or https://foo.com). That’s an even simpler case than the redirect case Bradley mentioned.
+So it is already not the case that HTML will logically resolve things. It isn’t a big leap from there to use assertions as part of the key. My personal preference is still Alternative #2, but I see the arguments the HTML maintainers are making. HTML is still an open standard, welcoming of participation. We could decide to go for the weaker constraint but then over time find that all hosts we’re tracking are actually meeting this tighter constraint, if HTML decides to change this, and we could make a needs-consensus normative change to tighten the constraint. That’s another evolutionary path.
+
+GCL: I guess I was trying to clarify, given a module source text, with two import statements with the same specifier but different assertions -- what constraints are applied to that?
+
+BFS: I believe in my last reading of the HTML integration, there is the potential for a parallel fetch to occur. I don’t think you’re guaranteed to be able to encounter that scenario.
+
+DE: HTML is single-threaded, just like JavaScript, for the main thread that’s driving these fetches. The imports will not be racing.
+
+GCL: I meant on the JavaScript side, what’s the constraints?
+
+DE: In all JavaScript environments, you can count on the fact that if you have the same module specifier and the same assertions, you get the same module identity. But even stronger on the JS side, you know the module is not interpreted by the import assertions.
+
+This came up in a recent framework outreach call. Someone said that they want to make a webpack plugin to replace loaders with import assertions. And my response is that’s great, but let’s work together on a new TC39 proposal that we talked about before, where we decided to separate out import assertions from things that reinterpret the module. I hope we come back to TC39 with another proposal to take off some of this ecosystem pressure. But that’s entirely unrelated to HTML’s need, which is definitely not about re-interpreting the module, which is banned in all environments.
+
+GCL: Sure, I’m not trying to solve HTML, I’m just trying to expand my understanding. So within the same source text, the same module with two different assertions, can lead to two different modules?
+
+DE: If you use an assertion that is not recognized, that is what it would do. [Note: after revisiting the PR, it is clear that the HTML PR does *not* do this. The debate is between ignoring unrecognized assertions (not keying off of them) and erroring on them. Unrecognized attributes will not cause duplication in HTML.]
+
+GCL: Ok, thank you.
+
+SYG: When JHD and I discussed offline about alternative #1, the salient division for JHD’s concern wasn’t necessarily web vs non-web, but ahead-of-time tools vs. servers. I’m happy to help wordsmith the alternative to actually be reflective of the division that makes more sense here than web vs. non-web.
+
+JHD: Thank you SYG.
+
+BFS: I think we could take alternative #1 if we reframed it a bit to not just be purely for the web. I could go into more edge cases offline if anyone cares where we can observe a similar thing in node, which will use a similar behavior even if we’re reading off of a filesystem. There are other hooks we use in node, and in some other working groups such as tooling, where people are looking for cache-busting for development purposes. We don’t want to state that node is not a valid JS environment.
+
+DE: I’m a little skeptical of differentiating Node from offline tools. We’re seeing more and more different environments and tools that try to emulate the web to some extent or another. I don’t understand how you would carve out an extension for Node that would not apply to tools.
+
+BFS: In particular, in the call me, SYG, and JHD had, we’re talking about tools that have full dependency analysis capabilities, so they have access to the whole module graph at that time. Node doesn’t have that, we don’t read everything off disk when we boot up.
+
+SYG: DE, I was not thinking of saying something like “Tools, you are not allowed to do this” but to come up with a constraint like what BFS was talking about: if you are a host that made the decision to load everything at once, then you should follow this constraint, otherwise you don’t have to follow that constraint.
+
+DE: The thing is that the tools cases that I’ve heard about are violating the other constraint that we haven’t talked about, which is reinterpreting the module. I’m not aware of any tools that have pressure to do this [clone the module without reinterpreting] one way or the other. So I don’t know why we would add this special bit of spec text to address that one maybe nonexistent case.
+
+MBS: I think maybe perhaps to BFS’s point, consistency seems to be important here, if the web needs a carve-out, it seems a little odd to call out that the carve-out for one specific environment. When we can’t really know what every environment and runtime is going to need. And I don’t want to get into the pedantry of what the definition of the web is. If we want to say browsers, that’s one thing. But I like the current text, which relaxes constraints on hosts and lets hosts make that decision. It’s harder to tighten later. I like the idea of either keeping it relaxed for all hosts, or tighten for all hosts. If we are going to move forward I would like us to be consistent. I do have a preference for giving more flexibility to hosts than not.
+
+JHD: MBS, you addressed my point, in general I’m saying that if a host comes to us and says that they want to do something, and it’s legitimate, we can get consensus to change the spec to allow it. I just want to make sure the spec is signaling the intended use, much like the text on Atomics about the memory model.
+
+BFS: We actually can’t loosen it later because there’s a forward compatibility breakage, because the numbers of instances of modules changes. So we do actually need to decide this. Because of the forward compatibility breakage, I would view that node use these kinds of assertions or ??? as part of the cache key. We get into cases where people are doing things that are weird like manipulating modules on disk, ???. We don’t want to get in the case where we produce a singleton, and then we loosen it, and get more instances, or vice versa. That’s breakage.
+I think just because the web needs this, node in all practical terms must have this same edge case allowed for it.
+
+AKI: Dans (DE, DDC), we are at time, status?
+
+DDC: Ask for stage 3 with the status quo of the proposal?
+
+SYG: I feel somewhat strongly that I like the current status quo of the spec text the best.
+
+[silence]
+
+AKI: Alright, let’s call that stage 3! Congratulations!
+
+### Conclusion/Resolution
+- Stage 3 for the status quo spec.
+
+## JSON Modules update
+Presenter: Daniel Clark (DDC)
+
+- [proposal](https://github.com/tc39/proposal-json-modules)
+- [slides](https://docs.google.com/presentation/d/1_dgRPueD2dwSIsVOXVexYOncCRrDPcm_CPnswq9zOe4)
+
+DDC: (presents slides)
+
+GCL: I know that the assertions that are being proposed here mirror what HTML will do, but it’s weird to me that they would also be a part of JavaScript itself. ??? that we would mess with their contents, that’s weird to me.
+
+DDC: One clarification - hosts can have JSON modules without having the assertion. So a host that doesn’t have the kind of MIME type security issue that the web has run into could have an import something from foo.json and not require the assertion. This proposal says that if the assertion is present, it must be treated as a JSON module.
+
+DDC: The second thing -- a design goal of import attributes, we leave it open for hosts to introduce assertions that are relevant to them, we saw JSON as tied enough to the language itself, Same kind of level of parsing JSON - it’s central enough to the language as opposed to something like CSS, that wouldn’t make sense to specify here.
+
+GCL: I don’t disagree that it’s a common thing, I just don’t like that we would be sort of claiming the type value there. I doubt anyone’s going to make their JavaScript engine interpret `type: json` as something else. It just seems like an unclean integration point there.
+
+SYG: I think it’s the reality of not just the web, but internet things have already locked down the meaning of JSON.
+
+GCL: I don’t have a problem with the name JSON, I have a problem with it being part of the host’s assertion area there, with the type name and stuff.
+
+SYG: I don’t understand the point. It seems harmful to give hosts that extensibility point, they would only harm themselves. Presumably if you want to leave it open, there should be some host for which it would be legitimate for `json` to mean something else in the future.
+
+GCL: I doubt anyone would want to do it. I just don’t want us to have a precedence of putting anything in here.
+
+SYG: So you’re worried about precedents for other types?
+
+GCL: I don’t want there to be any assertions built into the specification.
+
+SYG: I’ve heard that you don’t like it.
+
+GCL: Right because it could collide with hosts doing things. Maybe in this specific instance it doesn’t. ??? The general domain is already not available???
+
+CM: I was just a little confused about the discussion about changing the meaning of JSON. The meaning is fixed.
+
+SYG: GCL was worried that as a general principle, it seems like a bad idea for us to restrict hosts from interpreting assertions however they want, even if it’s JSON. My response is precisely because it is JSON, and that the internet at large has a very specific meaning of JSON.
+
+CM: I see. So the concern is that well you said JSON, but we know better than you and we’re going to give you some other thing.
+
+GCL: Maybe an example -- it’s not the JSON part, it’s using the name type in the domain of a host boundary, maybe the host wants to use the type
+And now all of the sudden we are taking up a string value from them. It’s not about the JSON part, it’s - 
+
+CM: It’s like having a reserved word.
+
+GCL: Just like we created Symbols to have a new namespace, it seems like we’re breaking namespaces here.
+
+DE: I think the idea of this - obviously we’re not talking about changing what JSON means, but import assertions have been proposed - during the whole discussion, there was interest in standardizing as much meaning as possible. At first we left it host-defined. But there was a lot of interest in sharing standard semantics across hosts.
+I think it’s really important that you be able to import JSON modules in the same way. We could require ??? syntax in different environments, but it wouldn’t allow those things to be ??? in practice.
+I think this is a path we could take with future features, either through assertions or evaluator attributes, and this is called out in the Import Assertions explainer, that we could define these in the future, just like we declare globals, and we would just have to pragmatically deal with this potential namespace collision. I think that’s what’s going on here and it’s reasonable.
+
+GCL: So maybe the problem there was my understanding of how hosts should ??? something would be bad form of doing that. 
+
+DE: No, space is definitely free for hosts to use. It’s like globals, where hosts and JavaScript share the namespace and we work through the compatibility issues pragmatically as we need to.
+
+GCL: Well this is just an update and I think I’ve said my point so we can move on.
+
+MM: Previously, I think I was the strongest advocate for immutability. I want to just clarify that I no longer have strong feelings that these things should be immutable. The reason why they’re no longer strong feelings is that the main objection to mutability was that there was this thing where there was no good place to stand in which to freeze it first - harden it first, transitively freeze it before anyone else gets it. But that’s not true with compartments. With Compartments, we can interpose an attenuator. In a TC53-style scenario, where the underlying machine already has Compartments, and where there’s a premium on putting things into ROM, that combination should enable a smooth expression of JSON modules that turn into ROM’ed objects that result from the JSON module in a smooth fashion that works with the way programs express themselves. The only incompatibility, if we did this by remapping the import namespace, would be if programs count on the mutability. But that’s just par for the course with moving to a more locked-down environment.
+
+JTO: I think the issue is that JSON.parse is a function; you call it once, it returns once, and it gives you your own copy you can do whatever you want with, and it makes sense for that to be mutable. When you import something, you’re getting something other people may also import and be able to get, so it is consistent to have different behavior here. I want to make sure that spectators have that in mind. It’s not as obvious as “this is what JSON.parse does, and so we should do that”.
+
+RBU: Slight favor of immutability. While JSON.parse does return a mutable object, the string that you put into JSON.parse is immutable. When you import a JSON module, you have no way of getting the equivalent of the input string to recreate that mutable(?) structure, so I don’t think this is quite the same as a simple JSON.parse.
+
+MBS: I want to remind folks about the history of where this proposal came from, and its relationship to Import Assertions. Many moons ago/about a year ago, some folks including DE worked on standardizing JSON modules. And part of the philosophy behind it was that there are a number of different module types that we’d like to see, including but not limited to JSON, CSS, HTML, and WASM, but that behavior was concerned as far as scope. And JSON was one of the ones that was rather straightforward. We have differing opinions with mutability, but there were at least a limited number of walls of the bikeshed to paint. After last TPAC(?), there was a security concern and we reversed it [TODO: what’s “it”?]. But we still need to allow JSON modules in the language. In node, you’re able to require JSON. Many people use this as a way to bootstrap applications. Configuration files, metadata, tiny replacement for databases -- there are so many uses for JSON in an application. And there’s value in asynchronously parsing jSON, which we don’t have right now.
+Which is a whole other thing to get into. I will stop proselytizing for a second. But the thing is that when we look into import assertions and all the generic ways to use it, that proposal grew out of this one need to enable JSON modules.  We’re getting to a point where we can have more consistency—but I think it’s just really good for us to step back and realize why we got here, what we’re trying to build, and maybe step back from some of the specifics. One thing I think about is enabling programming patterns that people are using today, and making it more consistent across the ecosystem.
+
+JRL: The mutable vs immutable discussion: first I want to say that I’m not going to block over this. Immutability isn’t in the language - nothing is immutable by default. If we had records already, maybe we can have this discussion. If you import something from node, it will be mutable. If you import from a module, it will be mutable. Surprising behavior should not be the default, and I think immutability would be surprising.
+
+MM: JRL’s point is valid, I just want to point out that there’s a surprise issue on both sides. To have the JSON that you’re importing be corrupted by something that’s unrelated also causes a surprise. So in any case, as I said, I’m not trying to force immutability. I’m backing off from that. I just want to make sure we understand that there are surprises on both sides of this.
+
+DDC: Thanks everyone for the discussion. I’d like to continue discussion in the proposal repo. Would this be the wrong time to ask for reviewers for stage 3?
+
+AKI: I don’t think so.
+
+MBS: I think it’s a great time.
+
+DDC: Any volunteers?
+
+[silence]
+
+AKI: Stage 3 reviewers?
+
+RGN: Sign me up.
+
+AKI: Thank you, so giving of you. Anyone else?
+
+[silence]
+
+AKI: Come on, there are so many opinions on this. Who wants to review it?
+
+JRL: I can review it.
+
+AKI: Thanks JRL. Well that’s two reviewers, more are welcome but two is the minimum.
+
+### Conclusion / resolution
+- Further discussion on immutability vs mutability to occur on proposal repo
+- RGN and JRL to review for stage 3
+
+## GetOption in ECMA-262
+Presenter: Philip Chimento (PFC)
+
+- [issue](https://github.com/tc39/ecma402/issues/480)
+- [PR](https://github.com/tc39/ecma402/pull/493)
+- [explanatory code sample](https://gist.github.com/ptomato/7f13d17f092ab30872f5b5fe663ca507) 
+
+PFC: (presents explanatory code sample)
+
+WH: I haven’t thought through all the implications of this but offhand this seems quite reasonable.
+
+SYG: I like the restriction here. Since you say the plan is to move the abstract operation to 262, would it have any use in 262?
+
+PFC: Not in the current spec. But if Temporal becomes part of 262, then it would.
+
+SYG: We can talk about it when the PR comes around, but we usually don’t want to include things without having any users. We want it to be bundled with the first user.
+
+PFC: Yes, that’s what I intended, I wouldn’t want this to go to 262 by itself.
+
+MM: The upcoming compartment proposal, and the realms proposal, and the lockdown proposal, all have option object parameters. Whether we adopt this would be something to discuss, but those are all proposals that are advancing that have options arguments, and maybe we could use this there.
+
+PFC: I would like to hear if the abstract operation we are currently proposing would be suitable for the proposals you mentioned. If it's not, then we should change it so they are coordinated.
+
+DE: I'm wondering if this would be a good chance to align with WebIDL and have the same semantics between undefined and null. That’s how WebIDL interprets its dictionaries which are the same as our options bags. And otherwise it’s the same, it’s just a bunch of property accesses.
+
+PFC: I don't think there was any particular reason why `null` was disallowed other than that it was already done that way in 402.
+
+JHD: My understanding of the motivation of the design for default properties where they trigger on undefined but not on null, was that null is like, I am intentionally supplying nothing here; whereas undefined is like, I don't care what goes here. On an options object, you might want the null to throw. For example, if you do an HTTP request that you expect to return an object, but it gives you null instead.
+
+DE: I’d be happy to consider this to be a separate decoupled change. I think we’d be considering null to be an empty options bag.
+
+MM: I think null should be taken as an intentional null and not as a default.
+
+## Intl Enumeration API for Stage 2
+Presenter: Frank Yung-Fong Tang (FYT)
+
+- [proposal](https://github.com/tc39/proposal-intl-enumeration)
+- [slides](https://docs.google.com/presentation/d/1IWOHZVkXL_qbjz4T76bXmtLh7VOrWkT-HJIH2ZwY6NU/edit#slide=id.g96c285a300_1_78)
+
+FYT: (presents slides)
+
+FYT: Asking for Stage 2 advancement.
+
+RPR: The queue is empty.
+
+SFC: I just wanted to ask the question about the privacy concern that was brought out. If we achieve Stage 2 today, is this the understanding of the committee that the proposal is safe from the privacy point of view, or is this the understanding that FYT will continue to investigate the privacy concern?
+
+DE: I see it as the latter. I think this is good to advance to Stage 2. I appreciate the work FYT has done. But I think we need external expertise for stage 2. By getting to stage 2, this shows to external reviewers there is enough buy-in for reviews. I support this going to Stage 2 with future privacy reviews before Stage 3.
+
+YSV: Ditto on DE's point, we should get an external review in stage 2 but we need that privacy review.
+
+SFC: Thanks for clarifying.
+
+JHD: Is it possible that future review would lead to the proposal being withdrawn?
+
+DE: I wanna say, I think we should be open to both possibilities. We could see the proposal adjusted but also the proposal rejected, we’ve seen some stage 2 proposals never go to stage 3. I think it's okay to go to Stage 2, even if the feature gets dropped.
+
+JHD: If we can foresee that being a problem, then maybe we shouldn't promote it to Stage 2. Because the expectation at stage 2 is this should end up shipping
+
+DE: Our expectation is that this will be successful. This is like Records & Tuples; there are concerns outstanding that could cause significant doubt on the proposal, but we can resolve those in Stage 2.
+
+JHD: it is a fuzzy subjective criteria, so it needs a bit more clarification
+
+FYT: Stage 1 says to identify cross-cutting concerns. Stage 2 does not yet say that you have to solve all of the concerns. For Stage 2 entrance it is not one of things listed in the requirements.
+
+SYG: In this case, I think Stage 2 is both warranted and important, because for the champions to do the extra work and seek an external review for privacy, we need to send a signal that it is a thing we expect, modulo the things that need reviewing. I think Stage 2 is a good signal to give the champions that we want them to do the extra work.
+
+RPR: Queue is empty.
+
+AKI: Gonna mention to everyone, if you want a tie-breaker opinion, all the chairs agree this is very standard to go to stage 2 in this situation.
+
+RPR: OK, queue’s empty.
+
+FYT: I want to request TC39 to advance to stage 2, any objections?
+
+(silence)
+
+### Conclusion
+
+Consensus on Stage 2!
+## Records & Tuples
+Presenter: Rick Button (RBU)
+
+- [proposal](https://github.com/tc39/proposal-record-tuple/)
+- [slides](https://button.dev/talks/record-and-tuple-tc39-sept-2020.pdf)
+
+RBU: (presents slides)
+
+WH: The difference between primitives and identity-less objects is subtle. Is the idea that if you go for the object approach, that these things would be objects, but that you're trying to avoid exposing any way of comparing their identities?
+
+RBU: Yes, the current invariant around identity would maintain ??? 
+
+WH: How would you specify something like that? We had a problem like that with NaN. How would you spec that these objects would have separate identities but there is no way to compare them? That's a negative assertion — you’re trying to assert that something is impossible in the spec.
+
+RBU: Deferring to DE for spec questions.
+
+DE: I don't think there's a lot different in the spec between primitives and objects in mechanics of identity. In terms of actual spec text there just isn't a lot there. I think it would be possible in theory to insert a spec bug that leaks the identity of a primitive. I like MM's reply below.
+
+MM: We've repeatedly talked about putting more invariants into the spec with the object invariants being the precedent. If the spec has something that violates the object invariants, that would put the spec into an inconsistent state that must be resolved. And likewise we have asserts that have the same meaning ?? Having negative assertions in the spec about what must not be possible is an example of something we should be doing a lot more of.
+
+WH: Why the need for boxing instead of just directly storing arbitrary values inside records and tuples?
+
+RBU: That’s a great question. We should address this in the context of this proposal. The main reason we wanted to add boxes is ergonomics. The driving force behind immutable data structures is that they're deeply immutable. There's no way to silently escape the immutable world. We talked about things like integrity domains. An integrity domain is a space over which we want to hold an invariant. For example, we think of Records as having an integrity domain of “string properties”, in that you can trust the string properties of the record to lead to immutable things. The trick with Box is that it forces you to verify the box on the way in and the way out. In order to put an object into a record, you need to box it. In order to use the object in a record, you need to unbox it. There's no chance that you accidentally escape immutability. That ergonomic idea is the main reason.
+
+RRD: You can assert whether there is a box or not in the R&T structure. If it doesn’t contains a box you can tell it’s immutable. If you see that there is no box in there, you know that you don't need to do a deep copy of the R&T. That could be done whenever someone passes an R&T to a function.
+ 
+WH: Does a box have to contain an object or can it contain a primitive?
+
+RBU: It's an open question. Do you have an opinion?
+
+WH: I do, but we now have a long queue, so let’s move on to the next person.
+
+KM: Would this just work off the document.all machinery? Like, would to object Tuple give you back the identity operation? If we did use the object it would use the same machinery as document.all?
+
+RBU: I have no idea.
+
+KM: document.all looks like undefined. If one side is true, the other side is false.
+
+MM: ???
+
+JHD: ???
+
+JWK:  I don’t like the idea of identity-less objects. I agree with Jordan in the issue. If it was an object, I think it should work with Proxy.
+
+RBU: On the first point, I think we should dive in to whether the axiom is useful, whether the bifurcation between primitive and objects works, ??? We should continue discussion on the issue.
+
+JWK: Proxy?
+
+RBU: We had some initial work on proxies. We have to figure out something for proxies but the actual mechanics I don’t remember. If someone from SES can explain?
+
+MM: The key thing about this proposal is that it is not deep immutability it's about shallow immutability. The immutability ends when you reach something like a box. The extension of the Proxy mechanism is that if the target of a proxy is a function, or an array, etc., if the target of a proxy is an identityless object, two proxies that have the same identityless object and the same handler, where the handler is immutable, the proxy itself can still be shallowly immutable. So the proxy still acquires the immutability status from its target. The proxy itself can still be shallowly-immutable. And when we use the shadow target, the target can use what is ??? The key important thing is this predicate that allows you to say is this deeply immutable. And deep ?? can go through a membrane ?? and anything that is not deeply immutable needs to be considered on either one side or the other of the membrane and be transformed.
+
+DE: more issues about proxies and R&T, a proxy over R&T would have little latitude to do anything because R&T is like frozen objects. [Namely, the Proxy invariants guarantee that preventExtensions Proxies have a target which is preventExtensions, and non-configurable properties are backed by the target as well.] So all it could really do is some other side-effect. On the shadow target technique, we would need some way to have a proxy handler to close over the shadow target while still having the same identity.
+
+MM: The handler would need to be part of the comparison, but if the target ???
+Same target being ???
+
+DE: For the same handler comparison to pass, we'd need a way to make the third part of the proxy a tuple for the shadow target. Overall I feel like Proxies for records and tuples would be a post mvp thing even if we go with object semantics.
+If you make a membrane over R&T it would more likely transform the R&T eagerly like what you would do with Object.freeze. Let’s close this topic and move down the queue.
+
+GCL: I really like what has been presented here, especially the boxes. I'm glad we were able to get that solved.
+
+JHD: Identityless object. One of the things with prototypes is that the R&T would have the appropriate prototype value from the realm, so that I don't see the prototypes across realms. How would this work with identititless objects? Would it be frozen?
+
+RBU: The prototype is part of the comparison.
+
+JWK: You are introducing identity discontinuity. Then the things are not equal across realms.
+
+JHD: If the core motivation for record and tuples ?? then the content should not matter ??
+
+RBU: We need to think more about cross-realm concerns.
+
+YSV: I wanted to express our support for this path of investigation. We've been reviewing the patches and thinking about how to implement this. One of the things that came up in discussion is that this concept could be applied in the terms of an “object without identity” instead of a primitive. For example, in places like Temporal, where we want objects that are effectively immutable. It may be simpler to write things out in the spec. When implementing, we could tag the objects with a hash-based equality. So the equality would be using this tag. I'm not too sure about the realms issue, but it seems like a good question to research, and I'm glad the Temporal champions are taking their time to look into this.
+
+RBU: You said “Temporal”, do you mean R&T champions?
+
+YSV: I did mean “Temporal” as a place where you can use objects without identity to simplify the spec.
+
+RBU: Yes, that’s something we talked about, but have not brought up yet and haven’t talked with Temporal folks about.
+
+BSH: If we go with these identity-less objects we can’t use those as map keys and sets.
+
+RBU: Only the Weak variants.
+
+BSH: OK, sorry I didn't catch that, sounds good!
+
+JHD: So the concept of identity is already confusing. Before ES6, it was objects. Now it's objects and symbols. This was already hard to explain and teach. One of the primary differences between symbols and objects is that objects have identity and symbols(?) do not.
+
+RRD:  I share your concerns about explaining the proposal  we would have the same semantics we have so far it's mainly on how we explain things to people. We could even continue to explain things in terms of primitives or at least as a similar concept. I agree this is a step back in terms of explainability though so we have work to do here.
+
+RBU: I think we should continue this discussion offline
+
+JHD: A primitive could have typeof object.
+
+JWK: You get a different “value” of symbol each time. You can’t say because 1!==2 so numbers have “identities”. This also applies for symbols.
+
+RBU: We overload the word "identity" to mean ???
+
+JWK: So I think symbols don't have identities, but objects have.
+
+SYG: We talked about some performance stuff internally in V8: how we might implement internalization. We lack concrete use cases where internalization needs this technique. Pseudo-equality checking doesn't really work. The cases where it would help are in repeated equalities to the ??same object??. Otherwise, you're wasting time crawling the objects to compare them. We're not sure where the use cases are where you are checking large immutable state. A corollary example after you do a ?? But that's a very different kind of internalization that means you recursively internalize every subtree.
+
+RRD: That would be very very interesting to have this type of optimization. Happy to discuss that later. (additional notes after conversation: by that I meant the optimization is important and is worth it, we can assist finding a good way to do it)
+
+PDL: SYG, get in touch because I have an example.
+
+## Class static initialization block for Stage 2
+Presenter: Ron Buckton (RBN)
+
+- [proposal](https://github.com/tc39/proposal-class-static-block)
+- [slides](https://1drv.ms/p/s!AjgWTO11Fk-TkehkMWh3eO58Dz2Izw?e=2JXhGZ)
+
+RBN: (presents slides)
+
+WH: I support this.
+
+DE: I support this, too! I think it's really great to have this as a follow-up to private fields and methods for the reason RBN explained, as well as class-based programming for grouping code. Banning arguments makes sense like they are banned for field initializers. The super calls, I don’t see any way those can possibly work, the proposal is great in its current form.
+
+YSV: No objection from our end.
+
+JHD: I like that proposal
+
+RBN: Stage 2?
+
+(silence)
+
+RBN: Any reviewers for Stage 3?
+
+DE: Me!
+
+PFC: Me!
+
+### Conclusion/Resolution
+Stage 2
+
+Reviewers:
+DE
+PFC
+
+## Process document clarifications
+Presenter: Yulia Startsev (YSV)
+
+- [pull-request](https://github.com/tc39/process-document/pull/29)
+
+YSV: (presents pull-request)
+
+WH: Thank you very much for converting this to positive framing! I like this version much better than the prior emphasis on individuals blocking consensus. One comment I can make is this assumes the only reasons something doesn’t advance are a constraint or a block.
+There is a third reason: a proposal simply does not have enough support. Nobody wants to block it, but nobody but the champion cares about it. It doesn’t fit neatly in this process document. I’d like to see this situation addressed.
+
+YSV: I agree that we don't have a good way of taking the temperature of the room. We usually go to silence. Silence could hide dissent. I would be very interested in a mechanism to gauge enthusiastic support for a proposal. I don’t think we have that right now, if we have a proposal I’d be happy to integrate it into the proposal.
+
+WH: People can find it intimidating or challenging to stick their head out to block something.
+
+SFC: I don’t necessarily agree that proposals should need enthusiastic support. There are a bunch of important proposals that don’t get people excited, such as ones in Intl, even though they are important proposals.
+
+WH: I think the intl proposals have more support than you realize, I think you don’t have to worry about that. An example of what I’m concerned about, to pick a silly example, if someone wanted to push for EBCDIC regular expressions, no one else wanted to push for it, most people were negative but not enough to dare blocking it, I don't think that's good enough for it to advance.
+
+SYG: The current PR adds quite a bit to the process document. I haven’t read the latest iteration, what’s your take on having it a bit terser without losing the meaning moving forward?
+
+YSV: I think I can get it done by November, the two long sections can be much smaller.
+
+JHD: Thank you YSV. Our committee has a long history of undocumented norms and everyone was OK-ish with it. I think that there is a long history of types of objections being appropriate for certain stages. Not in the sense that you can't object to a Stage 1 proposal due to a later stage concern, but more in the sense that Stage 3 means things are shipping. The types of concerns are different at each stage, and the kind of concerns that can be raised is limited. It’s really hard to read the room, do you agree? It’s also really hard to ask, 'do you object?' People will be quiet. Only the people with strong opinions for or against are going to speak up. And people with different personality types might not speak up. Is the default that everything advances with silence? Or is the default that things need support in order to advance? There might not be consensus on what the default is but I appreciate the positive framing. What I think is particularly useful out of this whole process, is what are some good incentives that we can document, like things that we haven't realized that are good on our process, and what are things that we haven’t be documenting that are bad and we can avoid. For example, DE suggested in IRC that, what if we had multiple people required to say, I enthusiastically support this proposal? More than one person would have to not be silent. I hope this can land and I’m thankful for people that provided feedback and to you YSV for this work.
+
+YSV: I’m really glad to hear your support and everyone else who helped. I want to touch on what you mentioned about introducing a way to more easily measure support, or sense minor negative feelings that aren't a block, to sense the temperature of the room. We need more experimentation. I wonder if we can experiment about this over the next year. Maybe it’s something added to tcq where delegate can put thumbs up and we can record thumbs up in the notes. Maybe it takes a form of what DE suggested. I'll take a look at IRC. I would like to see this change land independently from that time because the period to add engagement measurement. I think there has been some work here that is valuable that we can land ahead of time.
+
+JHD: I just want to add that some engineering cultures have difference between +1 and +2. Node.js has the custom of +1/-1 and +0/-0.
+
+SFC: The +1/-1/+0/-0 is known as the [Apache Voting Scale](https://www.apache.org/foundation/voting.html#expressing-votes-1-0-1-and-fractions), from the Apache Foundation. So we can take a look at it to get some ideas.
+
+YSV: I want a quick sense on what is supposed to happen next, should we continue async? Should we land this now and iterate or should we come back to it in November?
+
+MM: I prefer the November option. When this is about to land I want to give it a thorough read.
+
+WH: I agree with MM.
+
+?? (other people in quick succession): Ditto.
+
+YSV: I'll bring it back in November then.
+
+
+## Class Access Expressions for Stage 2
+Presenter: Ron Buckton (RBN)
+
+- [proposal](https://github.com/tc39/proposal-class-access-expressions)
+- [slides](https://docs.google.com/presentation/d/1ATxFyZUYv9WvmLMFPDIuJ5QSpoVTIdqM0ThH2JPpzFw/edit?usp=sharing)
+- [spec](https://tc39.es/proposal-class-access-expressions/)
+
+
+RBN: (presents slides)
+
+MM: When is this different than using the name of the class? In all the cases where it is useful, everywhere you use the `class` keyword, what happens if you use the name of the class instead?
+
+RBN: There is no difference in the semantics, it should behave as if there was the name of the class name but without the class name which is useful for long class names.
+
+MM: So, there's a problematic case that arises by using a keyword to refer to the closest enclosing class. The problem is nested classes. If you refactor something into a nesting class lets say yo put ?? now the occurrence of class refers to the inner function instead of the outer function, Whereas, if you always refer to things by name, you can always shadow, but you don't make shadowing accidents. So I really question whether this proposal pays for itself. If the price of not having this proposal is using the class name, and if the class names are usually short I’m not inclined to add such syntax to the language for such a small problem
+
+RBN: The shadowing problem is one I am aware of. We discussed it a few years ago when I first proposed it. It's a known caveat of the proposal. But the main goal is to provide a way of avoiding repetition, and don’t use `this` in static instead of `class`. (?)
+
+MM: I think that in the absence of the proposal, don’t tell people to use anonymous class and tell them to use a name.
+
+RBN: ???
+
+MM: And I think that's a minor cost relative to introducing the syntax.
+
+JHD: If you have nested arrow functions you need to have to store this in a lexical scope
+
+MM: This is known to be a hazard.
+
+JHD: If you actually needed to refer to both at the same time in the nested class, you'd need to cache `this` in a variable anyways, and you wouldn’t run into this hazard.
+
+GCL: Curious if you would extend this to an equivalent with function like `function.xyz` in an anonymous function.
+
+RBN: I can’t see that being the case. The main case was to differentiate static methods and instance methods with some syntax sugar around it. The use case for that I think would be fairly limited. There has been a suggestion on the issue tracker to use a new keyword like `static` instead of `class`, which has its own set of issues.
+
+GCL: I have no real use cases, just a mirroring sort of thing.
+
+RBN: Right now there is no plan for any type of equivalence.
+
+JHD: I'm very much in support of this proposal. One of the benefits of object destructuring is avoiding repeating a property name. There are tons of bugs that have been avoided by not saying "object.foo" because you only defined "foo" once. Simply avoiding repetition, is a good reason to do this. It's DRY to not have to repeat the class name. In snippets, you have to tell people that they have to go out of their way to match the class name. Similarly some classes are not named, in class factories you don’t name it directly. I think there is a huge advantage here, and the fact there are some cases where you wouldn’t be able to use it is not really a reason. in the same way that nested arrow functions in practice don't create confusion. People understand that `this` inside of arrow functions is lexical. There are a lot of options. Simply avoiding repetition is entirely sufficient for the extra syntax.
+
+RBN: I'd like to point out that a lot of my prior experience is with C#, which doesn't let you override a static method (you need to shadow), but it also doesn't allow class name dot for fields. It’s one thing we were discussing for ?? There is no common form or dotless form that you can use to access these fields. ???
+
+YSV: Feels like a papercut. Does it need a solution? I agree with MM's comments that this doesn't seem to carry its own weight. I've only seen this pattern once while programming. The factory class was named "Foo" and it was hard for someone reading the code to figure out what the class did -- this was a place where this could have been used. But if there had been no name there, it would have been even more for comprehension of the code base.  In this case, giving a name may make the code more clear than using a keyword. So I'm pretty -1 on this on the Apache Scale.
+
+SYG: I argued for private static being not so bad -- naming your classes is indeed a small cost IMO, agree with MM. Agree with this sentiment. Previously I was arguing private static to be not so bad. I don’t think the C# comparison to be that valid. In C# there is no way to refer to the instance of the class isn’t it?
+
+RBN: What do you mean by instance of the class?
+
+SYG: Is the instance of the class a first-class value in C#?
+
+RBN: Yes and no. You can use method to access properties, static fields, etc. on the class.
+
+SYG: Is it itself a value you can pass around?
+
+RBN: it’s been a long time since I spent time in C#
+
+SYG: Java doesn't have that. It doesn't make sense to compare to those classes, because there is no class object there is no compile time thing to refer to it?
+
+RBN: It's not as straightforward as with a class object. But there are ways like with reflection whereby you can access the properties as values.
+
+SYG: The comparison is not apples-to-apples. I think naming the class is a small cost.
+
+RBN: for readability, I agree, you can name your classes but I don’t think this is necessarily an issue to add this.
+
+PDL: I'm not aware of anything else in ECMAScript that allows accessing a keyword with a dot syntax. Syntactically, this seems like an outlier.
+
+RBN: we do that today with `import meta`, `new.target`. We already have metaproperties.
+
+PDL: It feels like we're introducing something where it is of questionable benefit given that there are other solutions out there already. Accessing from the keyword feels strange.
+
+WH: I’m impressed you made the syntax work — there are a lot of syntax icebergs in this space and you managed to get close but avoid them. But I also share the sentiment of MM and others. I don’t see that this additional syntax warrants the complexity and I am unsure if we should do this at all. So put me in the slightly reluctant camp.
+
+RBN: Many of the committee are fairly lukewarm on the idea and I was unsure what to do with the proposal, so I thought about bringing it up to either advance it or reject it.
+
+SFC: I’m not super enthusiastic, thinking about other languages, Python etc, this is exactly the behavior I would expect to see. Being able to self reference static functions is something I would like to see, at +0.3, but not strongly positive.
+
+JHX: I think the original motivation includes to solve static private field footgun, at this part has been removed; so I think the motivation is not very strong. There are issues with the decorator use cases that uses a dot form.For metadata. I think it's also like function.sent. function.sent is not a property on the function directly. The class part, maybe we should not use class dot to point to something directly. Maybe it shouldn't point to something on the class.
+
+DE: I’m having trouble understading JHX’s point. Decorator metadata is kinda like RBN’s Reflect.decorator module.
+
+RBN: He’s not talking about decorator metadata, how would you reference the decorated vs undecorated class. You could imagine a class.per, or something else.
+
+DE: So I mean, even that you need to access the metadata of the class. So a construction which is only available inside the class is not likely to be helpful.
+
+RBN: I’m not certain, even if, what about all the possible in-between classes, that result from decorators? JHX is basically saying that carving it out for property access enables it to be used for meta properties like import.meta or new.target.
+
+DE: I can understand how there may be other good use cases of the class keyword, but I don't understand how it would be used for metadata.
+
+JHX: I think the decorator usage we can discuss in the decorator proposal. What I expect is I feel the current motivation of class access is not enough after removing the static private field case. And I think it could based on the metadata it could have many use cases.
+
+SFC: Shout out for Yulia’s research calls. Most of the objections are on the basis of “what’s best for developers, what’s clear when reading/writing code”. It seems like the type of question that the research call would handle.
+
+YSV: The call is on Thursday this week.
+
+RBN: I'm not withdrawing the proposal, but I think ???
+
+MM: I am strongly objecting. Giving the question you are posing, I would retract the proposal.
+
+RBN: there was discussion about using static instead of the class keyword, this could be possible in strict mode
+
+MM: I don’t see that using `static` rather than `class` does anything at all to address my objections.
+
+RBN: I’d like to take some time before retracting the proposal. I still think there are some valuable use cases so I will not withdraw.
+
+WH: If you're going to do this feature, you should use the `class` keyword, but I'm not saying this feature should be done at all. I’m in the slightly reluctant camp.

--- a/meetings/2020-09/sept-23.md
+++ b/meetings/2020-09/sept-23.md
@@ -1,0 +1,579 @@
+# September 23, 2020 Meeting Notes
+-----
+
+**In-person attendees:**  
+
+**Remote attendees:** 
+| Name                 | Abbreviation   | Organization       |
+| -------------------- | -------------- | ------------------ |
+| Ross Kirsling        | RKG            | Sony               |
+| Dave Poole           | DMP            | Apple              |
+| Devin Rousso         | DRO            | Apple              |
+| Keith Miller         | KM             | Apple              |
+| Michael Saboff       | MLS            | Apple              |
+| Waldemar Horwat      | WH             | Google             |
+| Bradford C. Smith    | BSH            | Google             |
+| Chip Morningstar     | CM             | Agoric             |
+| Mark Miller          | MM             | Agoric             |
+| Kris Kowal           | KKL            | Agoric             |
+| Justin Ridgewell     | JRL            | Google             |
+| Shruti Kapoor        | SRK            | PayPal             |
+| Jordan Harband       | JHD            | Invited Expert     |
+| Frank Yung-Fong Tang | FYT            | Google             |
+| Jack Works           | JWK            | Sujitech           |
+| Mary Marchini        | MAR            | Netflix            |
+| Istvan Sebestyen     | IS             | Ecma               |
+| Jason Orendorff      | JTO            | Mozilla            |
+| Richard Gibson       | RGN            | OpenJS Foundation  |
+| SongYang Pu          | SYP            | Alibaba            |
+| Chengzhong Wu        | CZW            | Alibaba            |
+| Robin Ricard         | RRD            | Bloomberg          |
+| Robin Ricard         | RRD            | Bloomberg          |
+| Yulia Startsev       | YSV            | Mozilla            |
+| Ujjwal Sharma        | USA            | Igalia             |
+| Philip Chimento      | PFC            | Igalia             |
+| Pieter Ouwerkerk     | POK            | RunKit             |
+| Shu-yu Guo           | SYG            | Google             |
+| Hemanth HM           | HHM            | PayPal             |
+
+
+## Status update for class fields, private methods, static class features
+Presenter: Ujjwal Sharma (USA)
+
+- [proposal](https://github.com/tc39/proposal-class-fields)
+- [proposal](https://github.com/tc39/proposal-private-methods)
+- [proposal](https://github.com/tc39/proposal-static-class-features/)
+- [slides](https://docs.google.com/presentation/d/14ynZtqqlB9mCfK7iYdpwtO6hMV7dv9fVW0Z67PEwGzI/edit?usp=sharing)
+
+USA: (presents slides)
+
+WH: Can I get a clarification on the SpiderMonkey status?
+
+JTO: It’s implemented, private fields and private methods are all implemented, but it is inefficient, we want to tune it before shipping it. Later this year.
+
+WH: Thank you.
+
+LZJ: We have some concerns about class fields. I think that the define property semantics conflict with the traditional construction of classes, it is not compatible with the traditional constructor phase, and this issue must be resolved before entering stage 4.
+
+AKI: I’m not totally sure if I understand, this is just an update, this is not the time to address the finer details.
+
+USA: Maybe we can address this in the chat, or in issues.
+
+LZJ: Ok no problem.
+
+
+## Ergonomic brand checks for private fields for stage 3
+Presenter: Jordan Harband (JHD)
+
+- [proposal](https://github.com/tc39/proposal-private-fields-in-in)
+- [slides](XXX)
+
+JHD: (presents slides)
+
+BFS: I don’t think that those are the only two mental models we can have, they aren’t mutually exclusive. Having the ability to use a convenient operator like in is useful to me. Can we have the sugar of “in” and a collection API?
+
+JHD: Good question, personally my answer to that question is nothing prevents it. If a follow up proposal wants to do that, that's great.
+
+Should this proposal be blocked on exploring that. Sounds like you are implying it would be, I’m kind of neutral. That is a fair point, if having both isn’t automatic a non-starter, then it seems totally fine to pursue that second approach.
+
+BFS: That’s it.
+
+MM: I like almost all of this. I do think that the reified path is sufficiently separate that it shouldn’t be part of this proposal, the in syntax should advance, I am not interested in re-litigating the mental model which in a way ???
+Sort of property like, consistent with the syntax we have in the proposal, and consistent with the 2xx, things that are ??? 
+The reified form is really a much more specialized kind of use and very rare, for reflective purposes. That is the one where the mental model has to be the WeakMap model, and I think that it doesn’t need to be bundled into this proposal. The one disagreement I have with the WeakMap proposal is that I think the reified form should not simply be #x, the reason is another least surprise issue, for people in other class based languages, seeing #x they will expect it to be bound to this.#x. Reifying the name is weird, and doesn’t have precedence in other languages. I won’t mention concrete suggestions there but it is OK if that syntax has more ceremony to it, and is less easy to stumble on accidentally.
+
+JHD: One thing I forgot to mention, the inconsistency between string symbol and private fields, are intentional. We explicitly designed this over years of debate and perhaps considering perhaps too many alternative options, and this is kind of what we agreed upon. To me, suggesting consistency between private fields and strings and ignoring the fact that ??? was intentional is not a constraint that I agree with. Thank you for your thoughts on reifications and I’m not planning to bring forth a proposal for reification.
+
+WH: My position is almost identical to MM’s. I do not want to see reification using just `#x` because of what happens if you forget the `this.` — which a lot of people will do. If you meant to write `this.#x.get(…)`, and instead write `#x.get(…)`, it will work but do something you don’t want. I would suggest this kind of reification would be confusing. I support the proposal as is, without attaching or exploring reification.
+
+JHX: It is important to figure out what the reification syntax is. Whether it is #x or in #x, I really hope that the syntax could match so it will not introduce confusion even further. I understand that it may be reification could be a different level, but I really worry about that if we add some different syntax in the future, it will cause much confusion. I really think we do not need to rush, we should first figure out what the reification will be. Then we can finally decide the syntax of this proposal.
+
+JHD: One option is that there is no reification at all.
+
+JHX: If there is no reification at all, we need to first decide that. If there is no reification at all, we could reconsider the whole problem, whether the syntax is OK. All I want to say, the future of reification for me is very undecided.
+
+JHD: Can you help me understand why -- I agree the future of reification is uncertain, it is not worth our time to speculate. Why will it make a difference? Private fields already have a special syntactic form. There is no -- it is already entirely different from property access, the in syntax would be a special form. I would love to understand why reification syntax interactions such as adding another syntax in addition to the existing one will constrain the design space.
+
+JHX: I think I still hope that there will be -- should be -- as simple as it can. For example I think DE proposed another possible syntax of reification. It seems if we have two different syntaxes it seems worse.
+
+JHD: There are a few comments on the queue that may help with the discussion.
+
+DE: I was hoping that by writing out this concrete alternative, we would be investigating the space. What we found there proves out what MM said before in Feb, if we reify this, it will be different from the syntax in JHD’s proposal. It would also have fewer capabilities than full reification of the name. It becomes an alternative way to get at the semantics. It is unintuitive and verbose, but in my mind it is the most coherent design [for reification]. In my mind these are complimentary. I still think we can leave it as an open question whether we want to add this feature, because we know that if we do add this feature, it won’t interact poorly. I think that it is important to consider, and we have thought it through.
+
+WH: By “this feature”, do you mean `in` or reification?
+
+DE: Reification.
+
+DE: I am not suggesting that JHD's feature takes a dependency on adding the reification feature. I think the dependency is on us thinking through the design space and I think we have done that. 
+
+JRL: I think what JHX is saying, if we have `#x in foo`, that implies that `#x` can be keyed in computed property access like `foo[#x]`. My problem with that is that we already have `foo.#x` syntax, and we think of that as `WeakMap.p.get` in the map-like API. If we already have `foo.#x`, I don’t see how `#x in foo` matching a map-like API for `WeakMap.p.has` is that different. It is not a huge jump in logic for both of these syntaxes even if we were to reify into a WeakMap API.
+
+JHD: I certainly agree with that.
+
+AK?: How are we on clarity right now? Silence cool. 
+
+YK: I just want to say positive things. JHD did a good job of presenting the mental model, and that he did a good job stating why the syntax is. In general reification interacts with ??? Obviously that proposal is not going to proceed as-is.
+We will want to see how reification interacts with other proposals anyway, and there is no reason for us to wait on this for that to shake out.
+
+MM: The reified thing is a separate reflective level which is a much more specialized use, and we don’t know what the demand is. For the same rationale I don’t want to add syntax for other features. If there isn’t special syntax for it, how hard is it to do it yourselves? I pasted code in chat, that is a few lines of code that does this. If you have to do this all the time it will be a pain, but if you need to do it rarely you can roll it yourself. If we find that people end up doing this a lot even if it is 3 lines, then we have established a need. 
+```
+({
+  has: obj => #x in obj,
+  get: obj => obj.#x,
+  set: (obj, v) => obj.#x = v
+})
+```
+
+My suggestion is to not do any reified syntax until the needed is much greater than we currently expect.
+
+SYG: Throwing in my support for the in syntax with the #x in the LHS. On JRL’s point, if #x is on the LHS it implies that #x is a general expression, but because #x isn’t one it isn’t a problem.
+
+DE: One last point about reification, I agree with what others said about how this should only be added if there is motivation. It doesn’t add power, because you can do this with arrow functions. The decorators proposal (the new one) Is about having , when you decorate private fields the decorator is called with getter and setter functions to access with private fields. So this ended up falling out this??? Arrow functions that ???
+This all points to this being a rather well understood space, one where we already see different correspondences, in particular it doesn’t end up shaking out that we reify the whole private name to accomplish this.
+
+JHD: (continues to present slides, starting at “Open Questions”)
+
+JHD: Any thoughts on that point? That a syntax error is sufficient?
+
+MM: Syntax errors are sufficient, and the `a[#x]` syntax must produce a syntax error.
+
+WH: Same position as MM.
+
+JHD: Before I continue I want to give JHX a chance to respond again.
+
+JHX: Is it damning that everyone in the room thinks that reification will not use the #x form?
+
+MM: That is my position. That if we do introduce syntax for it, that it can’t be #x because they will expect it to be the value of the field.
+
+JHD: I am personally ok with #x being a property key of some kind, but I think that it perfectly meshes with the syntax. In the event that the syntax does not happen, because there is no syntax confusion.
+
+JRL: Are you asking us whether we are committing that #x will never be an expression form?
+
+JHX: My question is if any reficiation syntax — I guess it should be an expression. In the previous meeting, JHD said that if there is reification it could use [] syntax to access the private field.
+
+JHD: What I mean by that, is that we could — in the same way that object.#x is a special form. It is technically viable. Whether it would be acceptable to the rest of the committee is another question.
+
+JHX: I understand, it also makes sense to me if it work like that, that means that we overload all 3 operator, . in and brackets, and at least it have some consistency. It seems like if we do not go this path, we will only have .#x, and #x in, we only overload two operators.
+
+JHD: My response to that is, if they do something, they should have a relationship. If it is a syntax error, then it is clear there is no relationship.
+
+YK: I think this is related to what MM said, back when we first did private fields, we did #x as a property shorthand, we decided not to do that, part of the status quo, is that we are still deciding that in the future. I am fine if we decide to do it. I think that we punted because WH pointed out that it can have two meanings in static position.
+
+DE: Historically, how we made the decision around shorthand, we got past WH’s concern and were going to add it, but when people talked about the proposal, it sounded lexical. I was personally concerned that this would lead to mismatching expectations, if you had a function inside a class as a callback, it wouldn’t work that way. #x won’t make sense as the syntax for the reification -- in that reification each time you evaluate, you get a new function identity that closes over the private name, if you thought of #x as the name, if would refer to the whole private name, and would maybe come with extra powers like the ability to add a name to an object. There are reasons which MM articulated why such extra powers would be undesirable. For that reason separate from the shorthand concern, that we wouldn’t use #x for the name. The private fields and methods proposal is based around this concept of ordinary properties except a subset that throws exceptions when they are missing. The computed property case is always one of those, there is no way to differentiate the computed property from inside vs outside the class. The design of in is consistent with the subset.
+
+DRW: If you use a bare # private name, there is a concern with autocomplete. If you use a property name that is declared, we can provide autocomplete so that you write `#foo`, it will autocomplete to `this.#foo`, the `in` check is relatively rare, so you would need to allow it to rewrite it back to `#foo` if it sees the `in`, or let the autocomplete happen and rewrite it manually. Just a tooling concern.
+
+JHD: Hopefully I’ve explained the mental models and possible alternatives. Assuming I have achieved that, I would like to ask for Stage 3 for this proposal.
+
+WH: I support for Stage 3.
+
+MM: I support for Stage 3.
+
+JHX: Can I have some time to read notes that will help me understand some opinions? Can I ask for a half hour?
+
+JHD: Can we squeeze in a couple of minutes later?
+
+AKI: Before or after lunch.
+
+
+
+
+
+### Conclusion/Resolution
+
+Decision deferred until JHX can review notes.
+## Decorators: A new proposal iteration
+Presenter: Chris Garrett (CHG)
+
+- [proposal](https://github.com/tc39/proposal-decorators/)
+- [slides](https://slides.com/pzuraq/decorators-a-new-proposal-2020-09)
+
+CHG: (presents slides)
+
+WH: I'm confused by the explanation of init decorators.
+
+KM: Also confused.
+
+YK: Let’s continue and skip this for now, it is a minor part.
+
+DE: (presents slides)
+
+MM: How do the new decorators compare with guards? There are a lot of similarities.
+
+DE: I would rather discuss that in terms of a coherent guards proposal. I want to defer it to a future meeting when we have a thing to discuss more. Guards are a thing from MM and WH from 2014, where you can use guards to test that something meets a certain property. I just want to revisit later.
+
+MM: The motivating use case of guards is the ability to check the value on initialization or assignment. A guard would let you specify a function that possibly modified the assigned value or rejected it by throwing an exception. A guard is a type checker as well as a coercer. The idea of a function that just transforms the value that would be bound, seems in common with decorators. One important difference between guards and decorators is that for a decorated field you are intercepting the get and set actions via getters and setters, whereas guards only intercept writing — assignment to the field would go through the guard, but reading the field would be at full speed. Likewise with variables.
+
+DE: Yeah, so I agree with that analysis. I want to say more but i don’t want to lose people. I will very be interested in discussing guards in the lunch.
+
+YK: For MM, part of what is going on ,we have been looking -- I think a breakout and further discussion is important but I think you will be happy with what we are thinking. The other two things are I want to thank the committee in general what was sometimes frustrating but generally useful engagement. It took a while -- the other thing I want to say more concretely, the way this deals with values and possibly mutations, the way that decorators are either intercepting values or values + mutations, it feels like something has a lot more legs than something that was hard to extend. One thing that I like about it that is reactive, we can decide what to do in what order, we can do `let` decorators, it makes it pretty easy to see how we can do it. The flow chart for figuring out what it can mean is tiny, which is a nice property. Basically thank you everybody for dealing with us.
+
+DE: You can find that extension in the repo in EXTENSIONS.md. In this follow-on proposal, let declarations can be decorated to intercept accesses. We would be happy to hear your feedback on that. The current proposal is that fields/classes/accessors/methods would be included.
+
+DRO: It's more powerful. I have a question about decorating local vars and methods. I’m concerned about how that will work with subclassing and the performance implications of something like that. If you have a parent class with an instance foo, the decorator would create a getter/setter on the class. If a subclass also creates instance field foo, how would that work?
+
+DE: This is just about how class fields work in general. This is what typescript version is based on.
+
+The pattern of having a superclass and subclass that both decorate the same named field just doesn’t make sense in this proposal. If you have a field with no initializer, it sets that field to undefined.d The thing that would make sense is if we had something like in TypeScript, there is an option to upgrade to ES class field semantics (define instead of set), with a flag (--useDefineForClassFields), there’s a syntax to declare a field, based on erasure. If we wanted to allow you to subclass a class and decorate a field defined by a superclass, it would be decorated declate field, which doesn’t have the standard field semantics. I think that would be a coherent proposal to make. It would only act by setting metadata, but something you can make use of.
+
+DRO: Might have been my not understanding. But what about the local variable case? If you decorate a `let`, does that create an invisible getter and setter somehow?
+
+DE: Yeah, that’s how it would work. People have raised concerns about that. It’s not part of the MVP.
+
+DRO: I see, OK, I mean everything I have seen is the decorator is limiting the functionality to simply wrap function on the syntax level.
+
+DE: based on our use case analysis, it would be too limiting to not have field decorators. They come up in a lot of different contexts, that is why they are included in the MVP we are proposing.
+
+YK: Quick follow on, in the usage of Stage 1/2 decorators, public field decorators and class decorators are the most popular, it’s not that no one uses method decorators, but field decorators are up there. Writing the boilerplate for a getter/setter is noisy and pretty abstractable.
+
+KM: I totally see the value in getter/setter, the variable decorators in a class. The local variables semantics seem confusing, I would like to see it put off until it is more concrete.
+
+DE: Good! That’s what we are doing.
+
+SYG: I'm not sure I'm following your explanation on what actually happens?
+
+DE: There are two differences between the stage 3 class fields proposal and the Typescript class fields that they have, one difference is that if you have a field with no initializer it is set to undefined, and it uses define as opposed to set. In this case, they’re both relevant. The pattern that DRO mentioned of having both a superclass and subclass decorating the same field, I think only makes sense if field decorations are based on erasure rather than defineProperty undefined.
+
+SYG: Erasure?
+
+DE: The declaration itself doesn’t do anything, and the decorator does a side effect on the class, reading what the getter/setter is from the prototype, and writing a different getter/setter pair, or something like that. This is not a pattern that makes sense when the subclass defines a field that shadows a super class’s field.
+
+SYG: So in the new proposal, DRO’s use case will result in what exactly?
+
+DE: I’d have to look more at the details in what he is interested in. I bet there is a way we could rephrase it, I would have to know more about the goals.
+
+SYG: Fine, I don’t think it’s very important.
+Are the champions open to doing this piecemeal? For each specific decorator to be its own proposal—once we agree on the general architecture, it seems very clean to have different proposals with different decorators.
+I would like to know what the core set of what you are doing, field decorators are far most important. Some of it seems almost like a mystification of a function call. If those cases can be resolved ???
+
+DE: I want to understand more about this pushback on things that are function calls. I think it is generally useful to add function calls where there weren’t any before. This is a piecemeal proposal, by only adding field/class/getter/setter decorators we are not adding the full set. We’re flexible about adding or removing certain element from this. But I’m skeptical that just fields would cover the use cases in the ecosystem that we’re trying to cover here.
+
+SYG: That’s fine.
+
+YK: Yes absolutely, I agree that the nice thing is that you can get a picture in your head and decide which ones that you want. There is a tradeoff of something that you want done, it might make two ways to do the same thing. There is two way. There is wide use in the ecosystem (the Stage 1 proposal).
+
+Another way to think is that fields and methods can’t have functions around them, same with getters/setters. I think the thing I want to say about classes, they are more complicated than you think, the exact timing that the class becomes bound to the name of the declaration matters a lot. It is still an open issue, if you wrap a function around a class, you have the inner class and outer class, the inside class might see a different version of the class than the outside. It resulted in this becoming popular in the ecosystem.
+
+DE: KG asked this on IRC, how is a function call not already possible in a class declaration? If you used a function call, the inner class binding wouldn’t be updated. If you said after the class declaration Element = Function(Element), a class decorator can affect the inner binding.
+
+YK: If you want to use instanceof on youself it better be the same thing.
+
+SYG: That doesn’t answer my question. I don’t consider that a slam dunk as much as field/method decorators. I am very happy about that state of things.
+
+DE: We’ve talked before about deferring class decorators, it would make me sad but not completely ruled out.
+
+SYG: I want to thank the champions to take implementation feedback very seriously and redesign it.
+
+LEO: I’ve never heard of the term piecemeal. If I understand you mean fragmenting the proposal into many proposals?
+
+SYG: Specifically, I find some of the decorators more must have than others, and if the champions were interested in splitting them out.
+
+LEO: Ok, I understand you are trying to get an MVP, but I might be a little afraid because of class fields being too complex, I’m kind of afraid of that adding too much complexity. I feel this proposal looks a little bit small and enough for us to go ahead. I’d like to ask for my preference of going for this in a single proposal.
+
+SYG: I think I don’t agree that the current proposal will have the same entanglement issues than the previous proposals.
+
+DE: I share SYG’s sentiment. You can think of classes as a 2x2x2 grid, filling in entries, but this is more like you can use the same concept in different ways. Not a testing matrix.
+
+LEO: Thanks for the clarification. I’m trying to understand better. We can work this out.
+
+RBN: There is a small issue with breaking it down, if we were to advance fields but not methods, a transpiler like babel or TS would have issues transpiling some but not others, and troubles with users moving between versions, because they want to mix and match. If full decorators comes out it would be problematic. I would like to look at getting parameters included as well, but it is a separate topic. Piecemeal would be difficult for the transpiler world.
+
+WH: I’d like to understand the design of how all of the various decorator kinds work before advancing any of them. The pitfall we’ve fallen into several times is that when designing some kinds of decorators we find issues that make us reconsider design decisions on other kinds of decorators. If we were to approve decorators piecemeal, the danger is that we’d that we’re locked into a design that doesn’t cleanly extend to other kinds of decorators we want to add. So I’d prefer to understand the entire design first.
+
+DE: Yep. We are proposing doing this together, I share the reasons that RBN raised. It was a pragmatic case for including parameters. Even though they aren’t part of the Stage 2 proposal, they are in the ecosystem. I want to point out that this is friendly for upgrades. You can have a decorator library work for both legacy/experimental decorators and this proposal: it can check the type of the second parameter to see which style it is being invoked in. If the second parameter is undefined or a property key, it's a old style decorator. If it receives an object—the context parameter—it is the new version of decorator.
+
+YK: I agree that RBN’s point is good. Parameter decorators are not in babel, but trying to move together things that exist in the ecosystem is a pragmatic point.
+
+WH: I’d like to understand what init and metadata decorators do, I did not understand that from the presentation.
+
+DE: I’m going to defer that because I can’t answer that in the 3 minute timebox left.
+
+WH: Can you write an explanation?
+
+DE: It is in the README.
+
+BSH: What are the intentions that are built into decorators, for example if you decorate a method, does it ensure that it takes the same number of arguments?
+
+DE: For that particular one, that is something you can do with a type system, but there are a lot of other things that it by construction preserves. There were all kinds of shape changes, in this proposal you don’t end up changing the class. A lot of variability is reduced, but we are not adding checks to check arguments.
+
+BSH: For class decorators it does decorators a class and return a class, ?? was given.
+
+DE: The answer to the question is no. We can discuss this more in the decorators call, I want to learn more about these invariants. 
+
+I want lean more about what you want . thats not awared by previous decorators.
+DE: Do people have concerns on the high level, thanks for feedback.
+
+(ends)
+
+## String.dedent for Stage 1
+Presenter: Hemanth HM (HHM)
+
+- [proposal](https://github.com/mmkal/proposal-multi-backtick-templates)
+- [slides](https://docs.google.com/presentation/d/1OihdYij2Nwox1i-XgdAyTBZCatHXxpGvXiQsK0Qmvnc/edit#slide=id.p)
+
+HHM: (presents slides)
+
+DRR: (asks on queue: I understand ``` ``` is not necessarily the syntax, but that code is valid today)
+
+DRR: Weirdly enough, ``` followed by ``` is 2 tagged lit invocation, it is a runtime error, it has no problem with static syntax, it can be a syntax error. I don’t know if it’s worth changing in parser. Just wanted to mention that.
+
+HMM: we were kind of expecting that as a con, thanks for the mention
+
+KG: Express a preference just having the API, not having the syntax, at the very least for a first go, if the API is not sufficiently ergonomic or if there is still a need to add the syntax, we can do it at a later date. For now I don’t see why we should do the syntax, we should probably try the API
+
+JRL: The engine itself is maintaining a strings array, the Syntax form can never expose an underlying strings array - there’s only the dedented one. The engine only maintains the dedented form.
+
+JRL: If we `String.dedent` at the tag we can maintain semantics with syntax, and the dev using wrapper can only receive a dedented strings array. This is just a case if it's intended to return an underlying strings array or only a dedented one at the tag site.
+
+SYG: it seems there should be an opportunity for optimization?
+
+
+JRL:  In syntax, yes. But the API form will not be able to do that, since the engine will maintain the underlying strings array and dedent will have to maintain its own cached version of that.
+
+SYG: That answered my question and if that is the main con I also prefer the function over syntax here.
+
+DRR: I'm still confused.
+
+JRL: There's an un-dedented strings array, which will contain four spaces. That's one template strings array. If you were to pass in a `String.dedent` tag, you would get back a template strings array that does not have the leading four spaces. So there's two instances of a template strings array, one maintained by the parsing engine and one maintained by `String.dedent`.
+
+DRR: I see. OK, and because of that there's a potential optimization loss. For this to be efficient it needs to be cached, though maybe that's not so bad in the grand scheme of things. I don’t have a good handle on this.
+
+JRL: The dedented strings array absolutely has to be cached, it will break a lot of tag functions libraries otherwise. But there is a cost, because the engine will parse an underlying strings array, and string dedent will need to process that underlying array and maintain its own cached dedented copy, so there is a runtime cost to this.
+
+SYG: I must have missed something basic. The proposed API function returns an array, not a string?
+
+JRL: Yes, an Array of… There are multiple different ways you can use `String.dedent`. One is as a template tag wrapper. In this case, we’re invoking `String.dedent(html)`, so `html` will be invoked with a dedented strings array, because we’re using the wrapper form of String.dedent. If instead, you were to invoke String.dedent without a wrapped function, this would return a string to you.
+
+SYG: I see; I will read the explainer; I am confused myself.
+
+JRL: I recommend the REPL, where you can experience the API form.
+
+HHM: if you pass a string it returns a string, if you pass a function, you get a tag function which will invoke the function with an array.
+
+RPM: A reminder that this about getting this proposal to Stage 1.
+
+WH: Is there consensus on how dedent measures the amount of whitespace? Let’s say one line starts with 10 spaces and another with a tab, what’s the “common” whitespace?
+
+JRL: There’s differences based on which npm API you use. Each one of the current npm modules does a different thing here. The API I’d like to propose is that if a tab were encountered and a space were encountered, these would count as “different” and neither would be removed. Any kind of mixing would not remove anything.
+
+WH: And what’s the definition of whitespace? Is it the same as in the lexical grammar?
+
+JRL: Yes, it’s defined as Unicode whitespace.
+
+MM: Just historical note the JS template literal comes from the E quasi-literal. It had a dedent that people liked it. Are millions of people used it not for the template but for dedenting strings?
+
+HMM: From the module dependency, we saw a number of cases. A few are trying to generate code (e.g., SQL) and a few are trying to generate templates.
+
+MM: ok, personally having written a lot of template literals and seeing it starts on the left column, I found out using it directly without a dedent was pleasant
+
+(next queue item: Does this work when content is included on the first line?)
+DRR: It seems like that for lack of a better word, the algorithm you’re using means if the developer includes content on the first line after the triple backticks, then none of this would work. Is that correct, or is the “algorithm” more sophisticated?
+
+JRL: What I believe you’re saying, if the dev would include any content on the same line as the opening triple tick? That first line would count as the line with significant content in it and we would use that in the calculation of common whitespace. It could be that we forbid any content on that same line, so you are forced to go to the next line. That’s not a decision we’ve made yet.
+
+BFS: There is already a non-error triple backtick syntax, if there is a tag in front of them, they could produce a value but I believe that no such code actually exists though
+
+```js
+const a = () => a
+a ``` ``` // not an error
+```
+
+DRR: I feel relatively neutral. I have a few expectations around that dedent thing and how it computes. My biggest concern is this tag that takes a tag and checks if it's a function to determine its behavior. We spent a while trying to understand that. I'd strongly urge not doing the composable tag thing.
+
+DE: Decorators are often used in this way [of a factory pattern with a function returning something that can be applied as a decorator], if you apply params to decorators, those will be taken and will be taken next. You could use a similar approach to decorators, here the behavior is clear so I don’t see the problem here.
+
+DRR: It’s certainly possible, but I find it confusing. There are certain decorators that I would not encourage users to write as well.
+
+JHD: it kind of seems like composing template tags looks like a different problem to solve and maybe we should differently explore that and the template should always return a string and then we can figure out the composition case.
+
+MM: I would object to this proposal if it did not take a tag and return a transformed tag because the use case that this entire proposal is about is writing large templates where you want to indent a template as a whole, and not be part of the literal data that goes to the tag.
+
+MM: If you omit the composed form, then all you’re doing is dedenting a tagless template. And this use case is just a small motivation of the whole template literal.
+
+MM: The typical IDE will truncate the whitespace in the empty line, does your algorithm ignore blank lines?
+
+JRL: another open question: we could ignore empty lines, or whitespace -only lines, or ignore nothing (every line is used in common indentation). The current repl ignores only empty lines.
+
+MM: I think ignoring whitespace-only lines makes sense, I'd advocate we stick with that.
+
+HHM: Made notes of the open questions. Asking for Stage 1.
+
+SYG: I support stage 1 and want to ask which direction the champion group is going: function or syntax.
+
+HHM: We will lean more towards the function form.
+
+JRL: There are fewer issues with the function form, but I personally prefer the syntax form. There is a risk with web compat here with syntax, but the API form has those memory issues. Would be happy with either.
+
+SYG: Now that I understand the actual con there I do have semi-significant impl concerns, but they're certainly not Stage 1 concerns.
+### Conclusion/Resolution
+Stage 1
+
+
+
+## Temporal Stage 2 Update
+Presenter: Ujjwal Sharma (USA)
+
+- [proposal](https://github.com/tc39/proposal-temporal/)
+- [slides](https://docs.google.com/presentation/d/1wkufbATeIxKvYZmd_hlM80x9zJC-C6pTHVwDFtUSqfM/edit?usp=sharing)
+
+
+USA: (presents slides)
+
+JHD: Luckily you answered my question in the slides. It was suggested in July that the spec would be ready for this meeting because it will take more than 2 months. Please make sure the spec is frozen modulo naming concerns, so it won’t be overwhelming to review it and keep track of changes that are happening. That way you can ask in January. Second request is a document that explains the current mental model without the history and that document would be useful for the review. To reiterate, I love this proposal and I’d like it to advance.
+
+USA: I understand where you're coming from, and we’ll do exactly that. We have some rationale documents, if you can look around in them and tell us things that you are missing in there.
+
+JHD: I will certainly try to do that. But not everyone has the time.
+
+USA: The docs and the polyfill are important to understand the proposal.
+
+JHD: Personally I’d like to be able to review solely based on the spec and prose, and not look at the polyfill at all.
+
+USA: That’s great that you will review it that way, but some people may want to try out the polyfill when reviewing the proposal.
+
+PDL: We’d like to ask for reviewers later and review later because we don’t have those docs ready. In that spirit I’d like to ask people that want to look at it to make yourself known so we can give you more notice once the docs are ready.
+
+PFC: RGN might have more to say on this topic. We wanted advice from the plenary about whether to treat Temporal objects as "spreadable," namely whether they should be enumerable own properties or accessors on the object's prototype. RGN has stronger opinions on this topic than I do, so I'd like to invite him to start the discussion.
+
+RGN: The goal is to get feedback from the whole committee on this issue. Trying to capture the rationale for deviating or deviation is needed to put access and spread properties. I know the feedback about Temporal has been around verbosity. Also it works well with the pattern of library of treating a change that way. Do you have an example to pull up? https://github.com/tc39/proposal-temporal/issues/917
+
+MM: This is the first time I heard about this. I had previously been indifferent between own and accessor properties. I like it, the spreadable issue gives me a preference for own properties. It has to be own and enumerable in order to be spreadable.
+
+WH: When asking about spreadability, the choice presented seems to be either having hidden state in internal slots and accessors on the prototype or having own properties. If you use own properties, would those contain the entire state or would you still need some state in internal slots?
+
+RGN: Enumerable owned properties are the subset of owned properties that can construct the object with spread syntax.
+
+WH: Would the entire state be in own properties, or would there still be some hidden state?
+
+PDL: The data we store is actually from the ISO calendar representation. So, there is a hidden state in the sense that the actual version is the year, month, and day in the ISO calendar, yet the year, month, and day properties give you the calendar-dependent value. We want those properties to be spreadable while those internal slots hold the ISO representation.
+
+WH: I’m asking because I’m wondering if own fields and hidden slots could get out of sync with each other.
+
+PDL: No because they are computed directly from the calendar. Temporal objects are immutable, in that sense they are more like a record than a mutable object.
+
+JHD: The own properties are only immutable if Temporal makes them immutable, and that would be rare, since we typically use mutable properties. Accessor properties help ensure immutability. I think the problem that this tries to solve is an important problem—I have had an npm library for 9 years that allows you to combine a date with a time, it is a problem that needs solving, but I think object spread is very messy and might not work. For example if we have two different calendars in two different objects being spread, I expect an exception to be thrown, but it will not be, because the second calendar property overrides the first. If this problem doesn't have to be solved with object spreading, then there is no motivation to use an own property.
+
+DE: What people have been saying about time for reviews is true, but a misunderstanding about the time to do that. I like the idea of a call to go over the tutorial with reviewers, the polyfill can help people trying, I also want reviews from web developers and we’ll be accepting feedback. People should raise issues if there are issues with the 3 months review.
+
+PDL: On a side note, there will be a workshop  at NodeConf.EU this year to gather some feedback.
+
+
+## Intl.DisplayNames V2 for Stage 1
+Presenter: Frank Yung-Fong Tang (FYT)
+
+- [proposal](https://github.com/FrankYFTang/intl-displaynames-v2/)
+- [slides](https://docs.google.com/presentation/d/11Ch4Y9yYzMJjznX478Y0QbbCGiOAXbOzLjpYnMH9eck/edit#slide=id.g98718d9573_0_37)
+
+FYT: (presents slides) Asks for Stage 1
+
+SFC: Supportive of this proposal as it solves very complex problems. Especially in date/times so I support Stage 1.
+
+RPR: The queue is empty.
+
+JHX: In the slides it mentions leap months in chinese calendar, does it solve leap years?
+
+FYT: There are two different things, how do you format dates, not part of this proposal, in there suppose a gregorian calendar, and the formatter will output the leap month. This problem, given this API without any math in it, I ask for the first or last month here without math. But the problem is how do I account for leap months? How do I accept input the right way. For instance jewish calendar doesn’t have leap months but a 13th month. So we need to address that issue between Stage 1 and 2.
+
+JHX: Really like this, good direction.
+
+PDL: Strong support for this.
+
+RPR: The queue is empty.
+
+FYT: Asking for Stage 1.
+### Conclusion/Resolution
+
+Stage 1
+## Intl Locale Info for stage 1
+Presenter: Frank Yung-Fong Tang (FYT)
+
+- [proposal](https://github.com/FrankYFTang/proposal-intl-locale-info)
+- [slides](https://docs.google.com/presentation/d/1NwYFb6jm5aQOiL9urMM-GaEFMhll5sYcZJYQ1WZhTZ8/edit)
+
+FYT: (presents slides)
+
+RPR: The queue is empty.
+
+SFC: +1. I think this proposal solves another important need, like the unit stage 1 proposal to figure out the measurement system and this proposal is solving that so I;’m happy FYT is championing this and should go to stage 1.
+
+PDL: +1. This is really important, I am responsible for some of those hacky libraries myself.
+
+RPR: The queue is clear.
+
+FYT: Asking for stage 1.
+### Conclusion/Resolution
+Stage 1
+
+## Conformance for enumerable options in 262 and 402
+Presenter: Shane F. Carr (SFC)
+
+- [ecma402 PR](https://github.com/tc39/ecma402/issues/467)
+- [slides](https://docs.google.com/presentation/d/19rOwwfESiPhlv63deeBPt_RwfmOJNQq2Qc-PJngE770/edit?usp=sharing)
+
+SFC: (presents slides)
+
+MM: I want to mention 2 issues related without good answers for. There is no way to feature test what is supported on the platform. It should be very easy to feature test for something in transition. Providing options in a bag: should it ignore unknown bag properties or error? Neither of those works. Errors will break and ignoring will entrench bad options. Throwing is bad on platforms that doesn’t support but it is not a problem if we can start to feature test. Those option bags are really important so we should fix that.
+
+WH: MM, I'm not sure I understand your conclusion… are you saying that it's best to throw on unknown enums of a known option, or are you talking about unknown kinds of options?
+
+MM: I’m referring to unknown kinds of options, unknown options property. With regard to enums specifically, if there's an enum value you don't understand, there should be an error.
+
+WH: MM, that completely flipped the meaning of your comment for me; SFC’s presentation is about unknown enum values of known options rather than unknown kinds of options.
+
+MM: I see.
+
+SFC: The question of unknown kinds of options is different.
+
+MM: Sorry, I misunderstood the presentation.
+
+WH: How would you do a conformance test that an implementation accepts only the allowed enum values?
+
+SFC: Good question. The way we do it is that we give it an example unit value that exists in CLDR but not Intl as a litmus value. That is a very good question though.
+
+WH: My answer to the question you asked at the end of the presentation: I agree with you, we should choose case-by case how to proceed.
+
+JHD: In an options bag in the community, you could view it as a workaround for not having keyword args. Each option in an option bag is like a named argument. We don't make APIs that throw on extra arguments. The same should apply to options bags. We shouldn't throw when you add a new property. We should consider adding one of those things for things considered free to do. As a general policy, throwing when you pass an unknown value.
+
+JHD: If you pass a known option with an unknown value, you can throw.
+
+JHD: It's potentially a breaking change… people are more likely to pass an object with unknown properties than pass unknown arguments.
+
+JHD: With the latest timeStyle/dateStyle change, I had 3 or 4 reports of users passing date value in their option bags because the new version of chrome throws when passing on an unknown but did not before. Every time we decide to start throwing we potentially break people’s code.
+
+SFC: I just wanted to be clear that I agree about “unknown properties” in options bags.  We ignore them, which is the same approach we take in 402 and Temporal. The specific question I mentioned here is the case of unknown values to known arguments. Should we allow Chrome to accept “fortnight” as a unit and format it instead of throwing?
+
+JHD: if there is a way to feature detect then it becomes easier to deal with throws which is better than to deal with try/catch.
+
+PDL: One pattern I’ve seen before that instead of adding a bunch of parameters for a mix of libraries, one could pass in an options bag instead.
+
+The scenario that can therefore come up is that, in my combination of two libraries, I have an option that is supported by HTTPS but not HTTP interfaces, for example. There should not be an exception in that case. But if you throw on unknown options, you break the web.
+
+SFC: PDL, how do you suggest once introducing new values to the enums, or should the enums be forever fixed?
+
+PDL: you ignore it, because anything else would break.
+
+SFC: In case of the unknown unit fortnight, if the browser doesn’t have that data it, what is the fallback behavior? What do you do if you just ignore unknown string options?
+
+PDL: right. This is a big reason why options bags have a lot of issues (despite of the pros). An unknown value needs to be ignored.
+If it’s unknown and requires something, it is actually the new implementation that needs to deal with that
+Throwing is breaking the web essentially.
+
+MM: We've been leaning toward ignoring unknowns rather than throwing. The dilemma between the two is addressable. You can feature test. However, it's difficult to feature test for what options a given procedure supports, and what enum options it supports, but good for calling code to detect and address the problem.
+
+WH: For unknown enum values of known options, I think throwing is the best approach. For example, if you wrote `unit: "metre"` on the currently displayed slide [the slide has a `{unit: "meter"}` option], throwing on that is better than silently ignoring `"metre"`.
+
+SFC: We’re at time, to summarize: do option 3 on a case-by-case basis, to think about cases so we can support wildcard strings/enums. If we don’t have a reasonable fallback mechanism we should throw, and in all cases we should introduce a feature detection mechanism.
+
+FYT: Feature detection is actually solved in the Intl Enumeration API that went to stage 2 last night.
+
+SFC: For feature detection, you can also check if `resolvedOptions` has the same value as you passed in.
+
+PDL: That is the best rebuttal to WH because otherwise I can’t do feature detection if it starts throwing.
+
+WH: PDL do you agree with me or disagree with me?
+
+PDL: Disagree with you because we’re too late to do feature detection, we need to do it with what we have now.
+
+WH: I never said anything about feature detection. I’m very confused about rebutting something involving that.
+
+PDL: Will take that offline.

--- a/meetings/2020-09/sept-24.md
+++ b/meetings/2020-09/sept-24.md
@@ -81,7 +81,7 @@ SYG: In my spec draft, it is a RangeError.
 
 MM: RangeError sounds good. My other question is, how upwards compatible is RSB from GSAB and the others? Rather than adding two new types, I'm wondering if we can just upgrade the spec of the types we have, such that ArrayBuffer is growable according to the spec, and same with SharedArrayBuffer.
 
-SYG: Indeed, that was the first draft internally. Users liked it but the security team had to push back. Anything that requires us to audit existing array buffers and array paths, not just in JS engine but also in the web browser itself is ???. I wouldn't say it is a non starter but it has pretty big repercussions. 
+SYG: Indeed, that was the first draft internally. Users liked it but the security team had to push back. Anything that requires us to audit existing array buffers and array paths, not just in JS engine but also in the web browser itself uses ArrayBuffers in its code. I wouldn't say it is a non starter but it has pretty big repercussions.
 
 MM: So the issue is not the use of these by JavaScript code, but rather the use of fixed-length ones by things in the host?
 

--- a/meetings/2020-09/sept-24.md
+++ b/meetings/2020-09/sept-24.md
@@ -1,0 +1,783 @@
+# September 24, 2020 Meeting Notes
+-----
+
+**In-person attendees:**  
+
+**Remote attendees:** 
+| Name                 | Abbreviation   | Organization       |
+| -------------------- | -------------- | ------------------ |
+| Waldemar Horwat      | WH             | Google             |
+| Jordan Harband       | JHD            | Invited Expert     |
+| Bradford C. Smith    | BSH            | Google             |
+| Jason Orendorff      | JTO            | Mozilla            |
+| Richard Gibson       | RGN            | OpenJS Foundation  |
+| Chengzhong Wu        | CZW            | Alibaba            |
+| SongYang Pu          | SYP            | Alibaba            |
+| Mattijs Hoitink      | MHK            | Apple Inc.         |
+| Michael Saboff       | MLS            | Apple Inc.         |
+| Dave Poole           | DMP            | Apple Inc.         |
+| Chip Morningstar     | CM             | Agoric             |
+| Mark Miller          | MM             | Agoric             |
+| Kris Kowal           | KKL            | Agoric             |
+| Istvan Sebestyen     | IS             | Ecma International |
+| Devin Rousso         | DRO            | Apple              |
+| Jack Works           | JWK            | Sujitech           |
+| Robin Ricard         | RRD            | Bloomberg          |
+| Philip Chimento      | PFC            | Igalia             |
+| Yulia Startsev       | YSV            | Mozilla            |
+| Pieter Ouwerkerk     | POK            | RunKit             |
+| Shu-yu Guo           | SYG            | Google             |
+| Ross Kirsling        | RKG            | Sony               |
+
+
+## Revisit Ergonomic Brand Checks for Private Fields
+Presenter: Jordan Harband (JHD)
+
+- [proposal](https://github.com/tc39/proposal-private-fields-in-in)
+- [issue](https://github.com/tc39/proposal-private-fields-in-in/issues/7)
+
+JHD: The request I made last time was, can this reach Stage 3?  I wanted JHX to have time to respond.
+
+JHX: Thank you, JHD.  Thanks everyone for the patience. Last meeting, I was the only one who thought this was not OK. Thank you everyone for giving me a chance to comment, especially JHD and DE. Before the meeting I created an issue in the repo that summarizes my reasons for blocking the proposal. Basically, there are 3 problems. (1) conflict with reification; (2) syntax issue; (3) process. I think I have read the notes and the most important part is… I got new information. I want to summarize them.
+
+The first is about reification. In the last meeting, I said I was unclear on the future of reification. In this meeting, I think that at least I figured out some opinions of other delegates about reification. One important point was that if there is reification, it shouldn’t use `#x` syntax. I understand that based on two reasons.
+
+First, the potential confusion of `#x` and `this.#x` that may return a different thing. I think this is a valid reason. I agree. The only thing is that if this is very important, we should fix a similar problem on the public field! `this.x` and `x` give very different results. Of course this is not the issue of this proposal. I really hope that we can use the same quality standard everywhere.
+
+Second, reification is another level. You will not need that in most cases, so if there is reification, it should not use different syntax. I think I agree that… I think… it seems there may still be delegates who want reification in the `#x` syntax. I'm not sure about it. I can probably pass this part. The first reason I think it could be seen as solved.
+
+The second thing is about the syntax: it is likely to have reification.  I have to say, it's still not clear what the future of reification is. But I'll skip that because I think the reification problem can be accepted by me. On the second point, the syntax, I still feel the syntax is a problem. I think JHD said that private fields don't use the symbol semantics intentionally. I can't say whether this is a good idea. I prefer symbol semantics. The point is, I think that the current syntax, overloading `in`, actually violates this goal, and increases the mismatch of the syntax and semantics. I understand that most delegates think it is not so harmful. It seems it will not cause bugs in practice. I get this. It's hard to say how harmful it is. I think in the last meeting, there were some suggestions that we should discuss whether we want…
+
+BT: We're over our timebox. JHX, can you summarize?
+
+JHX: I need some time to finish; 5 minutes?
+
+BT: We’ll try to fit this in at the end; to be honest it’s extremely unlikely that we’ll have time. Could you provide 10 seconds of closing thoughts, JHD?
+
+JHD: At this point, I think JHX is the only one who hasn't provided consensus for Stage 3. It would be great if you could type up your summary so that we can reach consensus in November, or so that we can spend the next two months trying to get to consensus.
+
+### Conclusion
+
+Proposal does not yet have consensus.
+
+## Resizable and growable ArrayBuffers for Stage 2
+Presenter: Shu-yu Guo (SYG)
+
+- [proposal](https://github.com/tc39/proposal-resizablearraybuffer/)
+- [slides](https://docs.google.com/presentation/d/1MnLKwT5vgWX8x3jZ0i-z92Twm6EEaEEbhG9VwfONfXU/edit?usp=sharing)
+- [spec](https://tc39.es/proposal-resizablearraybuffer)
+
+SYG: (presents slides)
+
+JHD: On slide "Auto-length TypedArrays", when you said that when any part of the array goes out of bounds, then the whole array is out of bounds (?). So If i don't interact with a typed array if the ??? goes out of bounds, does the whole array goes out of bounds. 
+
+SYG: The way I wrote the spec, then that case is fine. If you never observed it going out of bounds, then it's ok.
+
+JHD: So it only gets locked in if you observe it going out of bounds? Great.
+
+MM: "Can throw OOM" -- What actually gets thrown?
+
+SYG: In my spec draft, it is a RangeError.
+
+MM: RangeError sounds good. My other question is, how upwards compatible is RSB from GSAB and the others? Rather than adding two new types, I'm wondering if we can just upgrade the spec of the types we have, such that ArrayBuffer is growable according to the spec, and same with SharedArrayBuffer.
+
+SYG: Indeed, that was the first draft internally. Users liked it but the security team had to push back. Anything that requires us to audit existing array buffers and array paths, not just in JS engine but also in the web browser itself is ???. I wouldn't say it is a non starter but it has pretty big repercussions. 
+
+MM: So the issue is not the use of these by JavaScript code, but rather the use of fixed-length ones by things in the host?
+
+SYG: Also JS code. It is a concern for correctness of implementation because there have been detached bugs and basically have generated a bunch of vulnerabilities for Chrome and firefox. If we were to generalize those paths have become battle-hardened over time. If we were to generalize those paths to support growable there's a risk of a long tail of security bugs.
+
+MM: So if we're talking just about JavaScript interacting with these abstractions, I don't understand. Because you still need to implement the new thing. You still have just as much risk of it being abused.
+
+SYG: Correct. If we implement it badly we will have vulns for these new types and these new types only. But if we upgrade the existing paths, we will have vulnerabilities not only of the new types, but also of the existing types.
+
+MM: You're assuming the users of the broken abstraction are the victims. I was thinking that you were worried about cases where the users of the broken abstraction were the attackers. If you introduce a broken abstraction that can be used for attack that's no less vulnerable than changing the old abstraction so that it's vulnerable to the attack. The attackers will go where the attack is possible. 
+
+SYG: I don't quite understand. For example, GoogleMaps uses typed arrays. If we screw this up due to implementation bugs, we break Google Maps. But if we implement a new type, Google Maps will not be affected, because they will not migrate to resizable array buffers.
+
+MM: In that scenario GMaps are the victim not the attacker. So for differentiating the victim your claim is valid. I question whether that's really the right security question.
+
+SYG: I welcome that point of view. As a PL purist, I agree. As the person who will have to find engineers willing to implement this, I think the current plan has a much more viable implementation strategy, namely that we don't have to re-audit all the paths. In Gecko or Blink, web audio uses buffers.
+
+MM: That's a case where there's a host using the buffer as well. That's why when you said “pure JS also argues for separating” that surprised me.
+
+Once you involve hosts as potential victims, sharing the same abstraction with a potential attacker in JavaScript, then the distinction makes sense.
+
+DE: I can understand this concern about web audio more easily than the Google Maps concern. I want to suggest a parallel concern exists in JavaScript. Previously, if you have an ArrayBuffer, you don't have the ability to change its length. But with RAB, now you have that capability. So that can have sort of downstream effects on other users. I was personally surprised about the initial version of this and making existing array buffers resizable. I'm pleased to see this restriction to be only resizable types. Tying down—not removing existing invariants about existing types. I am in support of the design that SYG has made. 
+
+MM: Having gone through this I'm in favor of it too. The WebAudio where there's a host victim and a JS attacker does make clear the need.
+
+WH: I don't understand SYG's answer to MM's concern. I don't understand the Google Maps example. What would be attacking Google Maps? Whether we have one type or two I'm not sure really makes much of a difference here. If you have two types someone could try to sneak in a resizable buffer where the client was expecting a non-resizable buffer. If you have a single class with a slot that says whether it's resizable or not, you get a similar situation. So I don't see what the issue is.
+
+SYG: For the Google Maps example since it was not clearly understood and I think we have resolved that issue I'll just retract that issue and hope we can move on.
+
+For the 1 versus 2 types thing, given that there is a lot of implementer and software feedback that we want two types, and given DE's comment about invariants, I think signs fairly clearly point to having 2 types is the better choice here.
+
+WH: Can you motivate that? I don't see much difference between two types and one type with a slot.
+
+SYG: It makes a real difference - I speak mainly as an implementer here - it's not a centralized place in a JS engine you deal with typed arrays. There are IC paths, different tiers of the optimizing compiler, that deal with typed arrays in different ways. Currently the invariant is that the length cannot change. You betcha the IC paths and the JIT paths take advantage of that invariant. (IC = inline cache, the implementation technique). If we were to relax that for existing buffers, we would need to audit each of those paths. Those paths are sensitive because they have been used frequently as attack vectors.
+
+WH: I was not suggesting we make all existing buffers resizable. I think you misunderstood my question.
+
+SYG: What is the one-type hypothetical?
+
+WH: Just like you have objects which are frozen or not, you could have buffers which are by default frozen-length but you could also request a buffer which is resizable.
+
+SYG: So like an overload of the constructor that the engine treats differently but from the language looks the same?
+
+WH: Yes
+
+SYG: If there were a clear predicate, I don't have too strong feelings one way or the other.
+
+SFC: This question of should we have one type with a slot that determines its behavior etc. has come up over and over again in Temporal, and the approach we’ve taken is multiple types, for discoverability, education, it works better with type systems like TypeScript, vs. methods that throw in odd situations. I think it makes sense to have separate types with separate behaviors here too.
+
+SYG: I do find that compelling. You would need a sophisticated system if all array buffers were resizable for example out of bounds accesses. 
+
+
+JWK: I think the maximum size does not make sense to me. Users will set it to a very big number so he won’t get [an out of memory error], this make the limit useless.
+
+For example I don't know what the maximum size it's possible to be, so I set it to very large and make this option useless. You can always treat this as developers want to set it to infinity. The limit doesn't make sense.
+
+SYG: Why is this a new problem from what is the status quo? Today at the risk of wasting memory you can allocate a very large typed array and just not use all of it.
+
+JWK: Yes, but it's already allocated. The problem is, in the slides, it says you need a maximum size in the constructor, but you don't have to allocate that much memory at the constructor time.
+
+SYG: You will figure one out. I mean I think most users of ABs which are such a low-level API, those kind of programs that deal with buffers that are sized will have some notion of what is the max size that we want. If you do not know ahead of time you can figure one out that is maybe reasonable. It's not a thing that you need to get exactly right. I don't quite understand the concern. suppose the people who are using this are going to be coming from C and C++ that already deal with buffers in this way. If you are going to reserve a buffer you usually have a notion of what is the biggest buffer we want to use.
+
+JWK: That answers my question, thanks.
+
+WH: I had a similar question: Maximum size and Hyrum's Law. I asked the same question at an earlier meeting and was wondering if you now had a better response. I looked at the spec; the max size limit you can specify is 2⁵³-1. If you put something bigger, it will throw. But this creates problems with Hyrum's Law. Ideally, users will carefully compute the maximum size they will need and ask for exactly that, but according to Hyrum's Law, they won't. They will just ask for something that’s ridiculously big, and if it works in the implementation they’re using, they’ll ship that. Other implementations that use a different virtualization strategy will be stuck.
+
+SYG: That is a real worry. I agree there.
+
+WH: I see this settling one of two ways. Either every implementation will allow 2⁵³-1 and go on their merry way, or implementations with much lower limits will have compatibility issues, or we will have to provide guidance for what people should put in that number. Expecting web authors to get this right is too optimistic.
+
+SYG: I share the concern. I have three sub-answers to that. (1) as pointed out by MLS, this is the problem of, let me reserve a very large number, has been seen in WASM memory.  I'm hoping to engage with the WASM and Chrome team to see how they deal with it. If it's a problem that exists for them today, then we can learn something there.
+
+MLS: I think I made that comment at the last meeting. Typically WASM allocates way more than they need, they just allocate the full 32-bit address space. At some point, you have a bunch of WASM web pages and you run out of memory on the system. You don't have enough memory to back it up on small systems.
+
+SYG: There needs to be some web platform guidance about reserving a huge amount of memory up front. I hope that all the engines that ship both WASM and array buffers will work together to figure out what is sensible and interop here.
+
+GCL: WASM does not require a max.
+
+SYG: Yes, but it accepts a max, which is the problem.
+
+GCL: I'm not saying we should not require max. I'm just saying that the thing that is considered good in WebAssembly is to start small and not assume a maximum. So the patterns might not translate over to us very well.
+
+SYG: I see.
+
+DE: My understanding of where we are today is that there was a lot of use of small ABs which had to be optimized in a way which wouldn't - where you wouldn't be able to apply the same optimizations as large array buffers, so that's why there was this split [between WebAssembly.Memory and other ArrayBuffers].
+
+I'm not sure that will come up again with resizable buffers. Maybe once they're marked as resizable they won't need to be optimized as small buffers.
+
+SYG: I do feel that as practically speaking if it is small, you shouldn't use a resizable buffer, you should use a small buffer. To go back to WH's question: (2) if you reserve a very large virtual memory range via the max length parameter and you exhaust your own virtual memory space, it seems like a "doctor: if it hurts don't do that" case, and if you get that error on your page, they shouldn't ship their product.
+
+WH: If they only test on popular browsers which are permissive, there might be issues with other browsers or less popular implementations where it only fails on those platforms.
+
+SYG: That  brings me to (3), I have left a lot of latitude for implementations to throw here, if they can't reserve the new page. I can imagine a system that throws for what feels like unreasonable max sizes. I suppose memory issues are in general not interop but I hope to work with Safari in particular to come up with something that's reasonable as a heuristic. I hope that is sufficient for now. I definitely agree that it is a problem. We need to figure out without letting people exhaust their own virtual memory. 
+
+WH: I'd like to either see guidance on this when we reach Stage 3, or assume all implementations will accept 2⁵³-1 and deal with it.
+
+SYG: If we can come up with something, then I would like to have a guidance note for implementations like we do in the memory model.
+
+PHE: I like the direction this is headed in. PST and I would be happy to look at this from the perspective of more constrained devices. One question: I may have brought it up but I don't see it addressed here - the typed array, sub array methodThe TypedArray subarray method, its (?) kind of conflicts with the elegant solution you have where the (?) tracks the underlying buffer. I wonder if you had thoughts on how to solve that, or if you just declare it not a problem - you just declare you wouldn't be able to create a tracked array which (?)
+
+SYG: Currently, all methods on both ArrayBuffers and typed arrays, if they return a new ArrayBuffer or typed array, that thing is backed by a fixed-length buffer. subArray - what happens in subArray?
+
+PHE: It would fail in that case.
+
+SYG: I'm trying to remember what I wrote. My intention is not for anything to return an auto-tracking typed array except by explicitly constructing it. Since that's an invariant the method happens to have now I would rather not relax it. Maybe there's a new case that throws. If there's demand for having an auto-length typed array, maybe we can add that. Pending data the plan is to not support it.
+
+JTO: I wonder if typed array access from JavaScript is meant to be as fast as typed array access to arrays backed by ordinary array buffers. What's the mental model? You have an implementation model to check at the last minute that the array is correctly allocated.
+
+SYG: My mental model there is that everywhere we have a typed array now you have to - outside the optimizing tier JIT paths where you have elided the detached check, you have to do that detached check. The detach check for resizable buffers is slower because you have to do the bounds check. That's my mental model: it will be slower in this case because it has to calculate this out-of-bounds. It's not going to be as fast until you hit the optimizing case. It won't hit this in the optimizing tier because JITs have an invalidation mechanism attached to the assumptions needed by the JIT code itself.
+
+JTO: Is this an anticipated common use case, or is it mostly for JS code to set up memory and then pass it to some host API that's going to do some magic with memory?
+
+SYG: I do think having JS dereferencing the typed arrays will be a common use case. I mean bounds checks can be - there's bit hacks for getting down the branches or whatever. I imagine these to be slower but not in the sense that - I don't know, like 100 cycles slower?
+
+JTO: You don't anticipate that this would affect the- … even in the IC-driven, non-optimizing tier, you don't expect this to affect the performance of existing tiers not backed by resizable array buffers?
+
+SYG: Because these are new types and the ones that are backed by resizable buffers you would give them a different shape and a different hidden class . That doesn't mean there won’t be a slowdown. 
+
+Where there's a slowdown is, if you have a program that mixes use of TAs that are backed by both fixed-size and resizable buffers in the same callsite, that will become polymorphic where currently they are monomorphic. That's a worry we will have to benchmark.
+
+JTO: Thanks for making that explicit.
+
+SYG: I would like to ask for Stage 2 and reviewers. I'm glad the Moddable folks have volunteered. I would also really like another browser vendor as a reviewer since this would because security folks worried. But first, do I have Stage 2?
+
+WH: I support this for stage 2.
+
+MM: +1, and I'd recommend you have Natalie from P0 take a look at this.
+
+SYG: I'd love to have her take a look. Since she's Google-internal I consider her not a reviewer.
+
+JTO: I'll ask our team to look into it.
+
+KM: I can review if you want another browser person.
+
+
+### Conclusion
+
+Stage 2. Reviewer companies:
+
+- Moddable
+- Firefox
+- Apple
+
+## Builtin Modules for Stage 2
+Presenter: Michael Saboff (MLS)
+
+- [proposal](https://github.com/tc39/proposal-built-in-modules)
+- [spec](http://tc39.es/proposal-built-in-modules/)
+- [slides](https://github.com/tc39/proposal-built-in-modules/blob/master/slides/BuiltInModules-For-Stage2-TC39-Sept-2020.pdf)
+
+MLS: (presents slides)
+
+WH: You mentioned the `BuiltInModule` (BIM) API is for built-ins only. But in the shim example, you had someone exporting a user-defined implementation of `"js:Complex"` if it was missing from that implementation. So how does `BuiltInModule` know if the module is a real built-in module rather than a user module?
+
+MLS: Actually you can add any user-defined module you want with a prefix you select and it would work. `BuiltInModule` can store user modules as built-in ones. I can export `Apple:Foo` and into the system so it can accept `Apple:Foo`, no issues. So yes, you're right, but we think this is a way that developers can provide their own modules at start-up.
+
+GCL: To me, this proposal seems strictly worse than just introducing a new `ES` global object that we put built-ins under.  I think BIMs are cool, and designing JS from scratch, of course I'd use them, but given all the constraints we have to fulfil with our standard library and all the API we are adding here and all the weird behavior we are running into, we have already solved it using globals. I get the namespace is busy but it seems to be that adding a new object solves better than what is being proposed. 
+
+MLS: How does that deal with the memory implications?
+
+GCL: Explain?
+
+MLS: That you don't pay the cost of the library that you don't use.
+
+GCL: Implementations already lazily load all sorts of values and stuff. 
+
+MLS: Implementations typically store only text. You are paying the price in text space, but worse than that you are going to incur some memory overhead before you lazily load features. So you're going to be paying a penalty for that. 
+
+GCL: Whatever magic happens to provide the API when you call the synchronous script API can also happen when you access a property on the global object.
+
+MLS: I have some backup slides. [switches to backup slides: Automatic Module Loading] SYG asked offline, why not just use globals? Developers are used to that. BIMs add extra complexity for devs. Conceptually, we could provide a loadSelf function that's internal, and for every built-in module, you would do a defineProperty. As soon as you go to access that object, it would load that module and add it to the namespace. You couldn't do this strictly in JS because you want typeof or instanceof Complex to be an object, not a function or anything like that. You don't want that type over instance (?) All the benefits of lazily loading are lost. So, the advantages of this is it gives module availability but gives a better programming model. It preserves the intent of BIMs, but you access them via the global object. They can be shimmed and polyfilled the way you are doing today. IT promotes a community built today. That is, when this is available, a developer can decide if they want to access the thing as a global property, or do they want to use BIMs? It would provide a standards means for built-in features. Most engines do lazy-loading except XS, and there's wonky stuff to make it happen. The other thing is that legacy feature can actually transtiion to be. (?) The disadvantages of auto-loading is that there are other JS hosts that couldn't care less about more things added to the global object. They're already in a module world. If we add this do we make it normal for browsers - and I don’t have answers for this questions. It doesnt solve pressure for namespace issues. It could also confuse developers for how do I get to Temporal or to Complex? That's a disadvantage.
+
+GCL: I don't feel like anything that was just said implied that BIMs are better.
+
+WH: You're showing slides that aren't in the presentation on the agenda; can you provide a URL?
+
+MLS: The latest slides were just uploaded.
+
+KG: Reload the agenda to get the latest slides. The link changed an hour ago.
+
+KG: I want to get more into the memory issue. I don't understand exactly where the benefit for memory in implementations come from. Is there a reason modules are significantly different here?
+
+MLS: In WebKit, we link in all the code. If something is lazilly added to the global object…  The reason we are doing this is because. The global object takes a long time to initialize.
+
+MLS: Primarily, our lazy loading is due to startup time for the global object. Which means that we’re paying the price for part of the memory cost of the objects. When you activate an object--when it’s used--you pay more memory cost to create the object, but you pay some anyway.
+
+KG: The thing I had in the queue was, there are APIs in the web platform that aren't synchronously available. You have to await a Promise. It seems that would solve the memory issue if a big complicated library is async available and you wait for the library to resolve. The only cost you are paying is for the library to load up at the start up. 
+
+MLS: The existing import function fits that, right?
+
+KG: Yes, it does, it’s just that--I am trying to get at, what the advantages are over the global. Maybe using it in a way that we don’t currently use it, by putting APIs behind asynchronous calls. We've already solved shimming problems with the global object: shimming, virtualization, etc. My company virtualizes tons of stuff so I care about that stuff. I would rather not virtualize additional APIs. I don't see the advantage of introducing BIMs over using the global.
+
+MLS: We already have modules we can bring in from the network. You don't see an advantage of those?
+
+KG: The advantage of those is that it allows users to organize their code in a particular way. But engines don’t have the constraints as users-- Engines can organize their code behind the scenes in ways that are not available to users.
+
+MLS: But users they are declaring their need for a particular module. they are going to load their module with an existing need they have. 
+
+KG: Sure, yes
+
+MLS: And, why don't we want to extend that to the local implementation?
+
+KG: Because you have to introduce a whole bunch of APIs.
+
+MLS:  I am talking about introducing 5 APIs.
+
+KG: They aren't trivial APIs. I’m not saying it’s a huge problem to add them; I just don’t see any advantage. I understand the memory issue with adding new synchronous complicated APIs to the global, just making the asynchronous. And then we don’t make everyone learn to virtualize things in a new way.
+
+BFS: In order to shim things, it must be done eagerly and synchronously. One of the concerns we brought up was loading and parsing source text. Somewhat on the tail end of KG, in order to avoid having shims always load source text, or any built-in that may not be present, we would have to wrap it in a Promise somehow. So, that means anything of sufficient size… the only way to avoid eagerly loading source text would be to have the promise be wrapped in an API, does not have to be a promise, could be something else. So it seems, if the expectation that BIMs are expensive to load, size, computation, etc., how are we expected to eagerly shim these without incurring that cost?
+
+MLS: The synchronous nature of shimming was a requirement for Jordan’s Stage 2 blocker back in Berlin, that it needed to be synchronous, for the classic scripts--they can use Promises, but you need to be able to do your shimming before the rest of the application runs. Unlike a network module, the module is part of the implementation. It may be on the filesystem or some other storage. It could be already compiled as part of a native dynamic library. So I don’t know if we could if we have to think that there’s always going to be a notable time access built in time because it can be optimized by implementation beyond source text. 
+
+BFS: Are we talking about users shimming it ? I can believe that, for host implementations, they always have it available ambiently, somehow. For shimming, they (???)
+
+MLS: If, shim or polyfill, if that comes across the network, you have the latency coming across the network. That no different whether its a built in module or global. There is no benefit in BIMs of something that needs to be shimmed. It shouldn't be any longer than it is now. Does that answer the question?
+
+BFS: I think it does . it seems it is an accepted downside. 
+
+GCL: If these builtins must be available synchronously, where does the load async benefit come from?
+
+MLS: You do an async import of a BIM. That Promise… I expect the implementation would return the promise already resolved. I think thats more of allowing a programming model of someone wants to use than a performance issue. If someone wants to use modules whether BIM or network, I mean sure. 
+
+GCL: So if you're an implementation that wants to take advantage of loading these async, how do you do that while also providing them sync? You said an implementation can load these modules async, but at the same time, the modules must be available synchrnously for scripts.
+
+MLS: If I had an API that added two numbers and provided a sync version and async version, they take the same time. One returns a value one returns a promise. So, loading the BIM async, it's going to be resolved and loaded, and you get back a Promise. It's a developers choice whether they want to optimize over the network or module. There is no need to restrict async vs sync. 
+
+GCL: So there's no benefit on the implementation on the engine side of the async option?
+
+MLS: Yes.
+
+JWK: This shim part of BIM makes lazy-load not possible. It shimmed part of the module, and it needs to import the module now to check if it needs to be partially shimmed.
+
+MLS: Yes, this is the first access of the module, which is going to do the “lazy load”. It’ll be fully available after this code runs, whether you’re polyfilling the whole thing or shimming part of it.
+
+JWK: But what if the partially shimmed module is not accessed in app code? And it's loaded unnecessarily?
+
+MLS: On the lazy load code slide, if the application already accessed the module, then the property would’ve been changed--if you noticed the load self changes the property in this case it is going to change complex. The getter will never get fired because they whole property has changed. Does that make sense?
+
+MM: I didn't hear; can you repeat?
+
+MLS: JWK was basically asking, do you polyfill the code first, or do you access it? If you polyfill, when you go to lazy load what do you get. Let's suppose you polyfill lazy load, the property on complex is no longer going to be the property you defined. Its going to be the actual thing you polyfilled. 
+
+JWK: I'm not mentioning about the global variable. My concern is about, what if the partial polyfill is loaded, but it's not actually used anywhere else? Only the polyfill is importing the module to see if it needs to be polyfilled. It's not used anywhere else, but the import cost is raised.
+
+MLS: Yea you pay the cost but the app has to have the disciple to only polyfill the things its going to use. If you don’t use this feature on the web page of application and you never use the module, in that case you polyfilled and brought it in later, that's just the way the application is written. 
+
+SYG: We’ve been talking a lot about the technical parts about polyfilling, sync/async, etc. From Chrome's position, and while I roughly agree with the position, I did verify this position up my chain, so don't shoot the messenger… from Chrome's position, let's separate the semantics of the BIMs and, once we have BIMs, are we going to use it for the ecosystem. 
+To me, that has two sub-questions: Are we going to use this for the web at large (outside of TC39), things that users don’t necessarily know to not be part of the core language--streams, fetch, data blobs, etc. And (2), are we going to use this for the JS standard library in TC39 itself? This is the ecosystem divergence problem. We currently have globals, people disagree on how well they work, but Chrome's position is that they work fine. So given that, if we suddenly have BIMs, users would have to understand, is this thing a BIM or is it a global, and how do I get at it? The thinking from the Chrome web platform leadership is that this is harmful. We should not diverge from standardized platform features to be available in two different ways. Chrome would not use BIM currently for new web APIs standardized outside of TC39. They will continue to use globals.  And (2), this is a weaker no, but should we use BIMs in TC39 itself? Chrome's position is a weaker no. I could reopen this question, but the thinking is that the same problem applies to JS features.
+From the web platform’s point of view, there is not a clear cut line that is beneficial to web devs between things that were standardardized. For that reason, it is very unlikely that if we were to get BIMs, that Chrome would ship the ability to import them as BIMs. So if Temporal were to be spec'd as a BIM and shipped under js:Temporal, the current thinking is that that wouldn't be made available. Personally speaking I think there is tremendous value in having a built in module machinery for other ecosystems that are not the web. I understand that it is not current champions group desires, so its not a value add for them.  But personally speaking, I think it's worth discussing the machinery separately from the ecosystem question. But on the ecosystem question, I think we are unlikely to ship new features as BIMs. If there were a sync capability that made it look like globals, the thinking is that we would ship those. The new BIM would only be available only via global like mechanism if available. 
+
+MLS: How do you see that TC39 would spec BIMs if one of the major browsers would not deploy it? Is it a normative optional feature that would be useful for TC53 or NodeJS?  How do we spec this?
+
+SYG: I think that the BIM, for the sake of argument, suppose that we agree to ship BIM global that you have proposed here. Suppose it was this thing like you have on the slide, where you have a magic globalThis.Temporal. We would ship that, but you can't get importjs:temporal. I am not sure(?)
+
+The contents of Temporal would need to be normative, but the way it were made available to users were flexible, globals or BIMs, the module part would have to be the normative optional. But thats a tech spec thing. I don't mean to imply in this position that, for example, the entire contents of js:Temporal would be normative-optional. I think that would be a bad outcome.
+
+JTO: Mozilla's position is similar. The fact that there's little interest from web standards bodies in migrating from globals to BIMs means that it would be harmful for JS standards itself to do that. It would  result in splitting the ecosystem. I want to emphasize that I am not opposed to the building blocks. Having a BIM system that could unify how BIMs work across other environments would be valuable even if the JS standard library doesn't go that route.
+
+MLS: My comment that I made is that I don't see that as providing one 1JS - which I think is the unspoken motto of TC39 - one JS. It is not a browser language or whatever. It is language. And so, to me, it seems like if something's in the spec, and we want to support and implement it, it seems incongruous to me that we would spec a feature that we never intend to use in the ecosystem even if we liked the feature. Why spec something we think is cool but we are not gonna use it?
+
+JTO: Mozilla would not be the target audience for that feature. We have no objection to the APIs being added and used by other hosts.
+
+MLS: The other comment is that Apple that participates in web standards would like to implement those [web standards] as modules, not just in TC39. 
+
+JWK: The requirements of “the shim code must be run before the main application” requires a big change in the module execution order. That requires some code be more prior to the other codes. I think this is not look good to me. 
+
+MLS: This is a requirement on classic scripts. Classic scripts must do shimming before the script runs. That is a req for classic scripts, and JHD can provide details there. 
+
+JWK: I think it might be possible to work around this problem by providing a new syntax-level block to indicate it is shimming some module, but don't execute the block until the module is first being accessed.
+
+MLS: I'm not sure how you'd spec that. It seems like you'd have a task you queue up that's dependent on the module. And there you would do the shimming on the first use. 
+
+BFS: Polyfilling globals must run before your main app code. There is some complex nuances to that. We have made it much more complicated to use top level await.  Top-level await causes interesting behaviors in sibling modules. There's a double-wrapping thing. It's not like this requirement doesn't exist already, so I don't know if we need to do anything about it, because you already have to deal with it.
+
+MLS: Yeah. CJS I think you need to do it in the engine. 
+
+WH: People were asking about how you lazily shim modules. Would a closure work? What do you mean by “some shims would need engine support”? 
+
+MLS: You could probably do it all in JS, but if someone needs to do it in the engine itself, we may not export enough APIs.
+
+In the example on the slide, this is conceptually what you would do. But you need to do more to make the property defined here. It is JS 80% eq of what you would do. The engine would have to know the internal object. 
+
+WH: The thing I was thinking of was, you could have a `BuiltInModule` export API that, instead of exporting a module directly, takes a function that it would call to define the module the first time someone imported it.
+
+MLS: okay so, on import kind of thing? 
+
+WH: Yeah.
+
+MLS: You could have an API that takes a closure, agreed.
+
+DE: I like the idea of an API that takes a closure for lazy polyfilling. There's a separate thing of async polyfilling, I know it contradicts some other constraints. You could fetch the polyfill if the module is absent or determined that there is something wrong with the BIM. So, I don't know if everyone here has read the previous import maps proposal that had a fallback list. It could be used to polyfill BIMs by picking the fallback only if the BIM isn't present. That API is rather limited; an imperative API here could provide more flexibility, but a key imperative is taking advantage of async modules. When we have dynamic imports, it gives spaces for the system to async fetches to get the module contents. So this could be great to lower the size of bundles in pages, which could really help application performance. I'd proposed an API for this in an issue. I understand the consequence is that BIM.import would sometimes return a promise instead of a module. This is a real technical benefit that would be impractical to get from promises. Temporal’s polyfill is very big. But we’re not going to change Temporal’s API to start with `Temporal.get()`.
+
+MLS: You made that as a follow-on or separate proposal, right?
+
+DE: I am very much in support of this proposal as is. 
+
+MLS: For async shimming, you were thinking a separate proposal?
+
+DE: I think it could be part of this or separate proposal. People were talking about the benefit. I feel like this benefit, of reducing the polyfill loading overhead from JS implementations in general that already have the BIM, is a big technical benefit to consider. But do you think it layers on top of the base that you have in a clear way. I can understand the problem of ecosystem split raised by Chrome and Mozilla but I don't understand the alternative raise of specifying something in TC39 for BIM that is not for the web. I think hosts already have the machinery they need to do this. In TC39, we'd be specifying something that's already there in code and common. I don't want us to get into - maybe we can make a task group, I would really like us to be unified. 
+
+JWK: Check out #67 on the repo.
+
+MLS: Stage 2?
+
+JTO: Mozilla will block.
+
+SYG: Since 1JS is a priority, the suggestion I had made is not coherent. So it's tantamount to a block. Since this proposal doesn't give anything that's exposed by js:, if the champion group doesnt see value in this dead machinery, then there is no value in having this machinery. We need to go into this with eyes wide open: at the point down the road where there is an attempt to standardize that Temporal is made available as a BIM, Google will block then.
+
+MLS: So what does the rest of the committee think about adding this as a mechanism knowing that multiple implementations won't use it?
+
+DE: I think we are here to make a standard we all agree on somehow. 
+
+AKI: I feel not positive about it.
+
+WH: What is TC53’s position on this? Would they use it?
+
+AKI: We are at time. Let's come back and discuss this more. 
+
+MLS: Google and Mozilla are on the record for blocking this. 
+
+### Conclusion
+
+The proposal will not advance.
+
+
+## Error Cause for Stage 1
+Presenter: Chengzhong Wu (CZW)
+
+- [proposal](https://github.com/legendecas/proposal-error-cause)
+- [slides](https://docs.google.com/presentation/d/1EVhRzCBUGynFnQoTdOCifoTJRWzhPMw8reIC5gtjGBk/edit?usp=sharing)
+
+CZW: (presents slides)
+
+CZW: Asking for stage 1.
+
+JHD: (in queue: why is this better than expandos, or an AggregateError, where the "errors" can be any values explaining the cause? ) Why is this better than one of a few alternatives, like expandos properties, or an Aggregate Error or a UserLand library? You also told us devtools could handle it. At the moment your example spec text allows it to be any value. 
+
+CZW: any value can be thrown so we are not limiting, so we can have any caught error as the cause even though js values don’t have much info, this is different from the stack. The cause is why this error happened so we can augment. For users if this array is thrown from deep internal, this might help to ?? these exceptions. The diagnosis will be more pleasant and easy to conduct. And why this should be in the spec, this way users  can confidently rely on the error (?) If this is in the spec, the user can safely just construct this property with this argument. We can attach to the error instance and we can analyze it for you and this argument and all is done here is no additional contract between the user and the devtools.
+
+JHD: To make sure I understood correctly, you're saying that even if this was just a convention, by putting it in the language, that encourages interop between languages and tools?
+
+CZW: Yes.
+
+JHD: OK, Thank you.
+
+GCN: While there are lots of ways to achieve that behavior, this enables debug tooling to reliably use this info. When it is expressly implied by the language, debug tooling uses it to provide a better experience. If you just put a bunch of related errors into an AggregateError instance, the debugger has no way of knowing, just because a group of errors are in an aggregateError, that they are related. These are two different things, and this is an important distinction. There is no implication that two errors (an error and AggregateError) are related, a chain, a causality relation.
+
+JHD: So you're saying it would require a convention to understand the causal relationship with the first AggregateError?
+
+GCN: Correct.
+
+BFS: I want to take it further than GCN, with the notion of breadth vs depth. With aggregate error, we get depth. This property gives us depth to that tree structure. This is really handy and gives us more information. In particular, an example would be, if there are two sets of errors that are cascading to two levels deep, your convention has to take into account that there are two branches to follow in the AggregateError.
+
+KG: I wanted to express general support for this. I have used the identical feature in Java and it is there. It’s great with tooling and IDEs in the case of Java. I do want to make sure we get all the devtools teams on board, since I see this being most useful for devtools. I don't see any reason they wouldn't be, and it doesn't have to happen before Stage 1.
+
+SYG: There is an incompat risk with Firefox as the Error constructor accepts multiple elements. I'd like to hear a Firefox delegate's take on that issue. I also have general support for this. I'll check with the Chrome devtools team and report back. A direct question for KG: What do you mean by getting the devtools team on board? There would be a special rendering of the `cause` property?
+
+KG: Yes, I would hope that when you get an error in console (printed or thrown). I would hope that the devtools teams would make it be a series of stack traces, like it is in other languages.
+
+SYG: I will ask them and report back to a future meeting.
+
+YSV: We reviewed it. I did see this compatibility issue but we didn't talk about it. I don’t think there would be an issue changing it as the feature is already not standard and probably not heavily used but something we should check. Additionally I can speak to our devtools team to cover KG's concern. That should also be no problem.
+
+JRL: (via queue message) Would love this for AMP. We currently mutate the error to add more message data, and occasionally set a .error property pointing to the original error. Standardization would be great.
+
+CZW: Can this advance to Stage 1?
+
+(silence)
+### Conclusion/Resolution
+
+Stage 1
+## Double-Ended Iterator and Destructuring for Stage 1
+Presenter: John Hax  (JHX)
+
+- [proposal](https://github.com/hax/proposal-deiter)
+- [slides](https://johnhax.net/2020/tc39-sept-deiter/slide#0)
+
+JHX: (presents slides)
+
+MM: (from queue: destructuring better motivated than double iterator) I like the ideas about the better destructuring and having rest in the middle. Doing it both for destructuring and for parameters feels right. Parameters might be more complicated because of all the other semantics on parameters, but at least for destructuring. However, I don’t find that desire worth it for double iterators. I understand the scaling point but in my experience, the destructuring patterns and parameter patterns are not used at the scale where scaling is relevant. It is not worth adding a second iteration and taking it up apart in the iterator match
+I think it's a fine way to implement it that doesn't imply any iterator change.
+
+JHX: There are two reasons. One is the scale issue, and the other is how you can double write the iterator in userland.
+
+MM: What do you think about the destructuring enhancements themselves without double ended iterators?
+
+JWK: JHX has presented previously, if we have no double iterator, then we must consume all the items in order to get the last few, which might not be desired, or have performance issues.
+
+MM: Thank you.
+
+KM: I agree it’s probably not a good idea, a footgun to (not??) have a double iterator.
+
+JWK: The performance is ??? 
+
+KM: If you have any kind of custom iterator, you'd have to run the whole thing. There is no way to optimise other than looping the whole thing. You can probably optimize but it would be complicated.
+
+JWK: the common case is destructuring from array, Generally no-one would change Array.prototype.values,then the engine will optimize it.
+
+KM: I am still uncomfortable with it because I am sure people will use it for other things on a custom data structure. Doesn’t seem like a stage 1 blocker for me.
+
+SYG: One thing I didn’t see in this proposal, is how the two parts of the proposal mesh together. I agree with MM that the rest operator is more useful then the double ended iterator. (not a stage 1 blocker but should be addressed at stage 2)
+
+KG: I support Stage 1. Definitely this is a problem that needs solving. Unsure about the current design presented here but I support Stage 1.
+
+WH: I don’t understand the `string.replace` example because that passes exactly 3 parameters in the spec. I find the behavior of getting the last function argument for destructuring to be dangerous for compatibility, specifically for callbacks like this. It precludes adding extra parameters to the callback in the future. I'm ambivalent about its usefulness for parameter passing. I also think that double-ended iterators make this too complicated, especially considering what happens when something doesn't support the double-ended API.
+
+JWK: You can design this api in a non-ergonomic way today so it won't introducing new problem.
+
+WH: It does introduce new problems.
+
+JHX: I tried to use the current mechanisms in JS already to achieve that. (???) I understand that the specific solution may be not very clear, but I think if I can advance to Stage 1, I'd like to update at the next meeting and have a long time to explain all the details.
+
+RPR: Those looks like details that can be explored during stage 1
+
+WH: I'm reluctant about the utility of some of this. That's all I will say.
+
+JHX: Asking for stage 1.
+
+(silence)
+### Conclusion/Resolution
+Stage 1
+
+## Standardized Debug for Stage 1
+Presenter: Gus Caplan (GCN)
+
+- [proposal](https://github.com/devsnek/proposal-standardized-debug)
+- [slides](https://docs.google.com/presentation/d/1TuLDmcjXuQmV3s6_thYCAlPaBLHO7ZM9pmCbS0oYcKw/edit#slide=id.p)
+
+GCN: (presents slides)
+
+JWK: It's possible to make debugger an expression that prints and returns the value. 
+
+GCN: Not entirely sure what you’re suggesting.
+
+JWK: I can leave an issue on GitHub. (https://github.com/devsnek/proposal-standardized-debug/issues/3 )
+
+GCN: OK.
+
+DRO: This sounds like that this is just a wrapper around the console.log function? Is there anything more special about this proposal that can't be done with a console.log function?
+
+JWK: `console` is not in the JS standard and requires adding it.
+
+GCL: The motivation is, when I'm working in other languages such as Rust, I don't have to write another function to do this. I don't have to think about how I'm going to implement my debug facility, I just do it. The big motivation here is like provide the functionality without creating your own debugging toolset. It's not a complex behaviour, but I think it's somewhat essential.
+
+BFS: I've presented on a similar topic in the past. One of the biggest things is that the values that are generated, don't have to be generated all the time. There are ways to detect that you're running in a debugger. There is a real world cost of generating values, if you look at prod logs of people logging often, there is a real CPU cost. Similarly, once you turn on debug logging, it just gets worse. Even having the values ready to put into debugger logging is costly. I would like to have something that tries to avoid these visible costs that we see today.
+
+SYG: The use case you presented is logging. It seems that the default behaviour of the keyword would have to be logging to be useful. The default for debugger keyword currently is that it traps. It only works when the debugger is opened. How would you feel if it did that?
+
+GCL: We don't have to use the debugger statement. I just put it in my slides as an example of something we could do. If implementations wanted to trap or log, they could. The point is that when augmenting it is useful.
+
+SYG: It’s a little abstract for me, I agree that the implementation latitude was needed. But if the browser implementation caused a trap, that would not be useful for your use case.
+
+GCL: We could discuss more in depth but I think ...???
+
+SYG: What I'm asking is for this to be more use case driven. I don't understand if the use case is logging or debugging. We could figure this out later.
+
+GCL: I would just say from my perspective that seems in the same realm. That would be if someone wanted to print they could ...???
+
+SYG: I would not consider logging and debugging to be in the same realm.
+
+GCL: In my use case I consider them being in the same realm of things.
+
+WH: If you want to define some library functions, that's fine. I would be very skeptical of defining new syntax such as the `!` operator in the proposal. The bar to add a new function call syntax is high and I don’t see how this proposal would meet that.
+
+GCL: The reason I bring syntax up is that implementations can take information about where in the source text it happens. I'd like to leave it open to further discussion, at least, because I think there are interesting pathways to explore there.
+
+JHX: I want to mention how Kotlin uses extension methods to solve this issue. A full ??? method which can be used on any value, and use value. Also and in the also closurdo debug, console log, etc… it is just a more flexible way. We could also have a specific syntax to add other things, if we have ext-like mechanism.
+I want to mention that a mechanism like syntax extensions, it could be used to test the idea.
+
+GCL: Interesting, we should discuss it.
+
+JRL: Can we have `debugger` in expression position?
+
+GCL: We can allow that if we wish. It's a constraint of the grammar.
+
+MM: I think that making debugger keyword be able to be used in expression position and having it throw you into the debugger with the value of the expression, a 'debugger expression' would be an expression just like yield expression could be an expression. Right now debugger can only be used at statement location. And it would naturally make the value visible from the debugging interaction. I realize that the debugging interaction is not something that TC39 specifies, but (???) This is something that they would plausibly do. The rest of this is not well motivated or interesting. I would drop the rest and keep the debugger expression.
+
+GCN: I find the use of syntax would be more interesting, I would like to go forward in that path I can consider function as a backup.
+
+WH: The syntax I was objecting to was things like adding a new `!` operator. If you want to play around with the `debugger` keyword and extend its syntax, I'm fine with that.
+
+MM: Great!
+
+JWK: (via queue) - https://github.com/devsnek/proposal-standardized-debug/issues/3 
+
+RBN: `debugger` being an expression in 2017-2018: We discussed the possibility of `debugger` being an expression back in 2017 or 18, when we were talking about throw expressions. At the time it seemed like an obvious "why wouldn't we do this?" If debugger was just debugger expression without any operands and there is almost no change to semantics it’s just syntax. I would consider using debugger.meta properties. There's a use case for debugger meta-properties that I was thinking about. VS Code shipped a new feature in their debugger for Node, that lets you evaluate an exprsesion in the debugger to give you information about the expression you have in your watch window. (??) I could see a possible use case of debugger. extensions something like debugger.typeProxy and watch it in another window. Or extensions that say I should step over this whenever I encounter it, for example. There's a number of interesting cases I could see that combine debugger metaproperties and decorators. This seems interesting for more use cases, and the idea is good but the syntax should be discussed.
+
+DRO: Some of the things that were mentioned already exist on the console "spec". Consider taking the console spec and making it part of JavaScript?
+
+GCL: If the proposal were to go in the direction of moving console into the spec I would withdraw it. I don't have any intention to poke that.
+
+GCL: Does anyone object to Stage 1?
+
+(silence)
+### Conclusion/Resolution
+* Stage 1 reached.
+
+## Unused Function Parameters for Stage 1
+Presenter: Gus Caplan (GCL)
+
+- [proposal](https://github.com/devsnek/proposal-unused-function-parameters)
+- [slides](https://docs.google.com/presentation/d/1zMH6qMZ_lAIedVui8hH1__dXbATF3Ur8gZppAlGR_r4/edit#slide=id.p)
+
+GCL: (presents slide)
+
+JWK: First syntax is error-prone, but I'm OK with the others.
+
+WH: You need to take care with the syntax. `*` will have issues with things like `yield*`.
+
+GCL: there are definitely some thoughts to be put into this, I'm not proposing anything specific here, so it should be fine to avoid scary stuff.
+
+WH: Syntactic support for `?` and `*` both seem really scary, for different reasons.
+
+RBN: I'm concerned about `?`. It conflicts with the partial application proposal which I still plan to advance at some point. It would lead to an extremely complex cover grammar to make that work. We already had to deal with complexity with arrow functions. Generally I prefer the elision mechanism (,, id) because it's similar to what we already do for elision in arrays. I’m also worried about star, it could be confusing just looking at documentation. Examples already legal since ES2015:
+```
+function f(...[, , x]) {
+}
+const g = (...[, , x]) => {}
+```
+
+BFS: I'm uncomfortable with any new syntax. I don't think it would be worth its weight.
+Elision is fine, If people want a placeholder it could be just a block comment, maybe people could use a linter to enforce it. If we talk about new syntax, I think no, but elision seems fine because the syntax is already there.
+
+GCL: I would like to move forward with elisions. It's something that's already in the language, we're just extending it to other places where you would expect it to work. But I hear the point about new syntax.
+
+JHD: I definitely think this is Stage 1, I like elisions, if it were Stage 2 I think the ??? should be solved. It solves a lot of problems that developers have, and would make a bunch of eslint rules unnecessary. We already support elision in array destructuring and we agreed to not add extra bindings for something like exception catch. This seems like the same scenario.
+
+YSV: We don't see a need to introduce new syntax for this, but we're also wondering if we gain something beyond _ as the variable name, because it serves to document which parameters are not being used. By introducing a way with not having any kind of naming, introducing a comment of what the name was. We're not convinced that this should move forward.
+
+GCL: As in the previous topic, I'm going to say that when I use this in Rust, it's handy to have the option to not name something you're not even going to use. It just one of those little things where you think the language is being effective, I agree it’s not a crazy new functionality.
+
+BFS: can you clarify YSV, about the mixed usage? Talking about block comment I would use empty block comments and it would be misleading to use anything else.
+
+YSV: Yes, people might find it useful, It's useful for the person who is reading their own code and knows what it does, or if there's some convention of knowledge around what's being used. It improves the provisionality of code, but it comes at the cost of error proneness. Ifound MF's comment about leaving a hanging comma might be a refactoring hazard, so I'm less convinced that we need this.
+
+GCL: Is that different from destructuring?
+
+YSV: If you are refactoring a function to take another number of parameters, you might be passing undefined somewhere you don't realize if you change the arity of a function.
+Let’s say you have 3 commas then var name you’re passing effectively 3 undefined values. If you update the function to have a different arity, this will be a silent error. It makes it difficult to see both your mistakes, and the intention of the original author.
+
+I'm not convinced that this is useful as it might seem. I know that it would be a popular feature, and may have heavy usage early on. But what we have now with the underscore may currently be better for codebase health overall.
+
+GCL: Just to clarify, underscore is one of the options here.
+
+YSV: I mean explicitly naming, that is underscore plus the variable name.
+
+MM: I very much agree with YSV, I have used bare _ in other languages. I found it unpleasant when I came to JS and couldn't repeat the single underscore. In JS not having this, I found it irritating, but using linters and tools we have today led me into the _name pattern. I rapidly came to realize it's actually better than what I wanted to do. I think this proposal is solving a problem that is better addressed by adopting new habits to name unused parameters. The gain is small enough that adding new syntax (even elisions) is not worth it.
+
+DRR: Technically it's possible to ignore something with an empty binding pattern. It looks pretty horrible but it is possible.
+
+JHD: It doesn’t work as it  throws on null.
+
+JHX: [] doesn't work.
+
+GCL: It sounds like people are objecting to Stage 1?
+
+MM: I object to Stage 1.
+
+YSV: I also object to Stage 1
+
+JHD: For stage 1 objectors: do you think it’s not worth committee time to ever discuss this again?
+
+MM: Yes.
+
+YSV: The demonstrated need is too small for the hazards that it raises. Having to discuss unnecessary parameters again might be worthwhile, but it might need to be in a different form or have overwhelming evidence that the limited provisionality this provides to the language overcomes the error proneness this introduces to the language.
+
+JHX: If we go through the object ????
+
+JHD: If you think there's a problem worth addressing then that is what Stage 1 is intended for.
+
+SYG: Falls onto the same guidance, people have objected to the need of this, given the info we have today, If new information comes up, then we can revisit.
+
+YSV: That is what I'm trying to revisit. It's not that we never talk about something again. It would be to our detriment to never bring something up again if it was rejected in stage 1.
+
+MM: Agree with YSV. Based on the present information, absent new data from the community, I think it's not solving a problem that needs to be solved. If new information appears, I’m fine with revisiting it.
+
+JHX: if a proposal is still Stage 0, can it have a user babel plugin to test?
+
+RPR: Babel is not bound by the TC39 stage process. Anyone can add a plugin.
+
+JRL: I can speak to Babel. We don't allow people to do syntax plugins. If you want to do a normal transform such as a comment or something you could, but it would be a little bit weird.
+### Conclusion/Resolution
+Not advancing
+## Modulus and Additional Integer Math for Stage 1
+Presenter: Peter Hoddie (PHE)
+
+- [proposal](https://github.com/phoddie/integer-and-modulus-math-proposal)
+- [slides](https://www.icloud.com/keynote/0c42Y16acgRtqdz7hEdtOtDFQ#Modulus_and_Additional_Integer_Math_-_September_2020)
+
+PHE: (presents slides)
+
+SYG: to make sure I understand: is the suggested semantics as `(x operator y) | 0`? 
+
+PHE: I'm not certain about some of the edge cases of that.
+
+SYG: I would like to know the answer because asm.js (??) is a thing now
+That said, I do generally support your proposal and these methods. Even though asm.js is a thing now, I don’t assume engines will continue to special-case asm.js syntax going forward.
+
+WH: To answer SYG, if you’re proving int32 inputs, the answer is yes for some of the operations and no for some of the operations.
+
+SYG: Which ones differ?
+
+WH: The simplest example is `Math.imuldiv`. The intermediate result is 64 integer bits, so you’ll get the wrong answer if you do it using IEEE double arithmetic and then coerce to an int32 using the `| 0` trick.
+
+WH: How this will deal with overflow? If you do `Math.idiv(5, 0)`, do you get infinity or what?
+
+PHE: It's a good question. The way that Patrick implemented it in the test bed is that it will return NaN in some of those cases. I don't recall that it returns infinity, but it might. We'd have to look at that on a case-by-case basis. My intent is that it would be a minimum of work on top of what the silicon instructions would do.
+We gotta look on a case by case basis, it would be fairly close to what silicon instructions would do for efficiency.
+
+WH: If you want to mirror what the processor instructions do you must not return any special values like NaN — if you allow these operations to produce a NaN or an infinity, the result will have 2³² + 1 possible values, which is hard to represent in 32 bits.
+
+PHE: There may be input checking to throw on invalid values. I don't want to get into it falling into lots of different cases depending on values.
+
+WH: Another fun case is -2³¹ / -1, which overflows a signed int32.
+
+WH: I just wanted to bring up these concerns as things to be addressed. The proposal looks good for this stage as far as I'm concerned.
+
+KML: Overall I like this proposal. I do wonder whether `idivmod` returning an array makes it more expensive than just doing idiv then imod and hoping the optimizer combines them. I don't know whether XS eliminates that array, do you even allocate the array? Usually object allocations are more expensive than almost anything else.
+
+PHE: That's probably my least favorite one. It seems like a good thing to be able to do this in one step, but you're right, in the testbed XS is returning an array and that is going to clobber any performance win from the math. These are definitely up for discussion; if there's no good performance win idivmod doesn't fit. It does parallel math that other languages have. I could go either way. It's really a question of what's the win vs people's concerns.
+
+KML: Totally not a stage 1 blocker, just a comment. (???)
+
+RRD: Maybe tuples, if they work as primitives, could avoid that allocation.
+That said, we might change the proposal to be objects.
+
+KML: I don't think you could avoid the allocation — you'd still have to allocate the tuple.
+
+RRD: Yeah, forget about it.
+
+MM: There's something about the algebraic identities here that I don't quite remember. What I think I remember is that the operator we're calling reminder is the rem from an integer division that truncates towards zero, whereas modulus is the remainder from an integer division that truncates towards negative infinity. I'm wondering about you idiv - which way does it truncate? For idivmod, having the remainder be the remainder being from the division portion seems right, and I'm wondering if it's even reasonable to have two versions of that, for mod vs remainder for truncating towards zero vs negative infinity.
+
+PHE: That’s fair, that would complete the permutations and combinations here—so that could make sense. On the details on the math, I’ll have to sit down and think about it for 30min.
+
+MM: Do you remember which way the idiv you wrote down truncates?
+
+PHE: I believe towards 0, but I'd have to check.
+
+MM: OK, I support this for Stage 1.
+
+PHE: Consensus for Stage 1?
+
+GCL: I’d almost say it could go for Stage 2.
+
+WH: I support this proposal. I’d like to see the semantics before this progresses to Stage 2.
+### Conclusion/Resolution
+* Stage 1!
+
+
+## Incubation call chartering
+
+- No notes
+
+
+## Mechanisms to lighten the load on note takers
+Presenter: Philip Chimento (PFC), Mark Miller (MM)
+
+- [issue](https://github.com/tc39/Reflector/issues/227#issuecomment-691092343)
+- [slides](https://docs.google.com/presentation/d/1uj33TfhhxC3Je0Q0H71QvyqMmToIVSEc7ivOfgY0g0k/edit#slide=id.p)
+
+MM/PFC: (presents slides)
+
+[discussion about using recording options]
+
+WH: We cannot make private recordings of the meetings for legal reasons. If we take video notes, they must be public.
+
+[discussion, with several people concurring with WH and explaining the issue]
+
+KG: Google has a TTS API that supports streaming. It is not free but it is extremely inexpensive. It would take some work to feed it into a Google Doc, but it could be done. We could hook it up to a Google Doc. I could do the work, but does anyone have objections? To be clear, this does not produce a recording; it only produces notes.
+
+WH: We say a lot of filler words when speaking that don't make it into the notes.
+
+KG: There would be editors who ensure the quality. They would remove the filler words and incorrect words.
+
+IS: +1
+
+SYG: +1 and send me an email. We could get you a coupon.
+
+KG: It costs, like, a dollar.
+
+RPR: Are people happy to continue?
+
+RBN: Teams also has this feature. I tested it and it seemed to transcribe audio fairly well.
+
+JHD: If recordings are out, this might be irrelevant, but recordings that we can't grep (text search) might create a chilling effect and make people uncomfortable. In the same ways, we don’t want notes to be 1-1 transcription and have those notes not be edited. But this is a moot point given the last discussion.
+
+WH: +1. Composing speech without lots of bothersome filler in real time is harder than writing things down. I used to take notes for the committee for many years. When I was the note-taker, the notes were higher-level than what they are now. I wouldn't mind going back to a slightly higher level than what we've been doing.
+
+RPR: People can currently edit notes either in the Google Doc or when they go into the GitHub PR.
+
+RRD: I would like high-level notes, but in some discussions, I don't understand everything that's going on. So that's why we end up with word-for-word transcriptions, because I don't trust myself to understand the gist of what someone's saying. So high-level notes sounds good, but it might be harder.
+
+YSV: Coursera has a cool feature. Quite a fan of the automated transcription / video scrubbing on coursera.
+
+MM: Can you do it after the fact?
+
+YSV: That should be possible.
+
+RKG: I am not a person that feels comfortable taking notes under the current process due to the extreme level of stress involved, but I would be inclined to help out in every meeting if it were a matter of post-editing automatic transcriptions.


### PR DESCRIPTION
These notes will be merged tomorrow.  Please incorporate any final review changes today by reviewing this PR.

There are a few places containing missing lines marked `???` attributed to these people...

- Resizable and growable ArrayBuffers for Stage 2:  @ljharb @syg 
- Builtin Modules for Stage 2: @bmeck 
- Standardized Debug for Stage 1: @devsnek @hax @erights 
- Unused Function Parameters for Stage 1: @ljharb @hax 
- Modulus and Additional Integer Math for Stage 1: @kmiller68 
- Ergonomic brand checks for private fields for stage 3: @erights  @ljharb @wycats @littledan 
- Decorators: A new proposal iteration: @syg 
- Import Assertions for Stage 3: @bmeck 
- JSON Modules update: @devsnek @littledan 
- Records & Tuples: @rbuckton @erights @ljharb 
- Align detached buffer semantics with web reality: @syg 
- Numeric literal suffixes update: separate namespace versionL @erights 

@syg We seem to be missing notes from Incubator call chartering.