### PR TITLE
Transfer "super construct proposal" document from ecma262

### DIFF
--- a/meetings/2015-01/ES6-super-construct=proposal.md
+++ b/meetings/2015-01/ES6-super-construct=proposal.md
@@ -8,7 +8,7 @@ applied to. That argument also is also reified as arguments to the `construct` p
 
     * There is no [[CreateAction]] or similar separable allocation step.
 
-1.  When a constructor is invoked via ordinary [[Construct]] and the constructor body was not defined using a `class` definition
+1.  ***When a constructor is invoked via ordinary [[Construct]] and the constructor body was not defined using a `class` definition
 that has an `extends` clause, then `this` is initialized to a newly allocated ordinary object whose [[Prototype]] is provided
 by the original constructor.
     * This is the way that `function` definition based constructors work today and must be maintained for legacy compatibility.  
@@ -46,8 +46,10 @@ is still uninitialized a TypeError is thrown.
 the `this` value is returned as the value of [[Construct]]
     * This is required for ES1-5 compatability
 
-1.  If a `class` definition does not include an explicit constructor definition, it defaults to: `constructor(...args) {super(...args)};`
+1.  If a `class` definition does not include an explicit constructor definition, it defaults to: `constructor(...args) {super(...args)};` if the `class` has a non-null `extends` clause. Otherwise it defaults to: `constructor() {};`.
     * If you define a constructor body then you inherit both the constructor argument signature and body from your superclass.
 
 ** There is agreement that this functionality is necessary. There is not yet consensus as to whether it can be deferred 
 until ES7 and on the actual special form syntax used to access the value.
+
+*** For the details covered by this proposal, an `extends null` clause  is considered to be equivalant to an absent `extends` clause.

--- a/meetings/2015-01/ES6-super-construct=proposal.md
+++ b/meetings/2015-01/ES6-super-construct=proposal.md
@@ -26,10 +26,10 @@ as the *originalConstructor* argument.   Subsequent references to `this` produce
 superclass constructor.
     * In other words, a `super` call delegates allocation and initial initialization steps to the super class constructor. 
 
-7.  When `this` is in its initialized state, any expression of the form 'super(<args>)' throws a TypeError exception. 
+7.  When `this` is in its initialized state, any expression of the form 'super(<args>)' throws a ReferenceError exception. 
            Rather than using [[Call]] to invoke the super class constructor.  
 
-8.  *** Within a constructor, `new.target` can be used, as if it was an identifier, to access the *originalConstructor* value.
+8.  ** Within a constructor, `new.target` can be used, as if it was an identifier, to access the *originalConstructor* value.
     * `new.target` can be used to get information about the original constructor (such as its `prototype` property)
 that can be used to manually allocate the instance object. It can also be used to discriminate [[Construct]] vs. [[Call]] 
 invocations.

--- a/meetings/2015-01/ES6-super-construct=proposal.md
+++ b/meetings/2015-01/ES6-super-construct=proposal.md
@@ -1,0 +1,55 @@
+This is the proposal presented and discussed at the Jan. 7, 2015 TC39 video conference call. This proposal would be applied to ES6 specification (except as noted).
+
+
+1.  [[Construct]] takes a new additional argument *originalConstructor* which is the constructor object `new` was actually
+applied to. That argument also is also reified as arguments to the `construct` proxy trap and in `Reflect.construct`
+
+1.  Built-in object allocation and initialization are merged into a single constructor function, just like in ES5. Note that allocation take place in a base constructor rather than the original constructor and uses 'originalConstructor' argument to determine the [[Prototype]] of the new instance.  The subclass constructor determines what arguments are passed to the base constructor which may use those arguments in its allocation and initialization logic. 
+
+    * There is no [[CreateAction]] of similar seperable allocation step.
+
+1.  *When a constructor is invoked via ordinary [[Construct]] and the constructor body was not defined using a `class` definition
+that has an `extends` clause, then `this` is initialized to a newly allocated ordinary object whose [[Prototype]] is provided
+by the original constructor.
+    * This is the way that `function` definition based constructors work today and must be maintained for legacy compatibility.  
+
+1.  When a constructor is invoked via ordinary [[Construct]], `this` is marked as uninitialized if the constructor body was
+defined using a `class` definition that has an `extends` clause. 
+    * If invoked via [[Call]], 'this' is initialized in the normal manner.
+
+1.  Any explicit reference to an uninitialized `this` throws a TypeError Exception 
+
+1.  When `this` is in its uninitialized state, any expression in a constructor of the form  `super(<args>)` accesses the
+[[Prototype]] of the active function and invokes  [[Construct]] on it with the current *originalConstructor* value passed
+as the *originalConstructor* argument.   Subsequent references to `this` produce the object value that was returned from the
+superclass constructor.
+    * In other words, a `super` call delegates allocation and initial initialization steps to the super class constructor. 
+
+1.  When `this` is in its initialized state, any expression of the form 'super(<args>)' throws a TypeRrror exception. 
+           Rather than using [[Call]] to invoke the super class constructor.  
+
+1.  ** Within a constructor, `new.target` can be used, as if it was an identifier, to access the *originalConstructor* value.
+    * `new.target` can be used to get information about the original constructor (such as its `prototype` property)
+that can be used to manually allocate the instance object. It can also be used to discriminate [[Construct]] vs. [[Call]] 
+invocations.
+    * An explicit return must be used to return such manually allocated objects 
+
+1.  When a function implicitly returns from a [[Construct]] invocation, if its `this` binding is still uninitialized 
+a TypeError is thrown.  
+    * This covers the case where a constructor with an `extends` clause  does not  invokes `super()`.
+
+1.  When a function explicitly returns a non-object from a [[Construct]] invocation and its `this` binding 
+is still uninitialized an TypeError is thrown.  
+
+1.  When a function explicitly returns a non-object from a [[Construct]] invocation but the `this` value has been initialized, 
+the `this` valus is the value of [[Construct]]
+    * This is required for ES1-5 compatability
+
+1.  If a `class` definition does not include an explicit constructor definition, it defaults to: `constructor(...args) {super(...args)};`
+    * If you define a constructor body then you inherit both the constructor argument signature and body from your superclass.
+
+*if necessary this rule could be changed to only apply to `function` definition based constructors and `class` definitions 
+without an `extends` clause. 
+
+** There is agreement that this functionality is necessary. There is not yet concensus as to whetherer it can be deferred 
+until ES7 and on the actual special form syntax used to access the value.

--- a/meetings/2015-01/ES6-super-construct=proposal.md
+++ b/meetings/2015-01/ES6-super-construct=proposal.md
@@ -8,10 +8,11 @@ applied to. That argument also is also reified as arguments to the `construct` p
 
     * There is no [[CreateAction]] or similar separable allocation step.
 
-1.  *When a constructor is invoked via ordinary [[Construct]] and the constructor body was not defined using a `class` definition
+1.  When a constructor is invoked via ordinary [[Construct]] and the constructor body was not defined using a `class` definition
 that has an `extends` clause, then `this` is initialized to a newly allocated ordinary object whose [[Prototype]] is provided
 by the original constructor.
     * This is the way that `function` definition based constructors work today and must be maintained for legacy compatibility.  
+    * The same `this` initializaton rules are used by both `function` definitions and `class` declarations that don't have `extends` clauses.
 
 1.  When a constructor is invoked via ordinary [[Construct]], `this` is marked as uninitialized if the constructor body was
 defined using a `class` definition that has an `extends` clause. 
@@ -42,14 +43,11 @@ a TypeError is thrown.
 is still uninitialized a TypeError is thrown.  
 
 1.  When a function explicitly returns a non-object from a [[Construct]] invocation but the `this` value has been initialized, 
-the `this` valus is the value of [[Construct]]
+the `this` value is returned as the value of [[Construct]]
     * This is required for ES1-5 compatability
 
 1.  If a `class` definition does not include an explicit constructor definition, it defaults to: `constructor(...args) {super(...args)};`
     * If you define a constructor body then you inherit both the constructor argument signature and body from your superclass.
-
-*if necessary this rule could be changed to only apply to `function` definition based constructors and `class` definitions 
-without an `extends` clause. 
 
 ** There is agreement that this functionality is necessary. There is not yet consensus as to whether it can be deferred 
 until ES7 and on the actual special form syntax used to access the value.

--- a/meetings/2015-01/ES6-super-construct=proposal.md
+++ b/meetings/2015-01/ES6-super-construct=proposal.md
@@ -4,49 +4,49 @@ This is the proposal presented and discussed at the Jan. 7, 2015 TC39 video conf
 1.  [[Construct]] takes a new additional argument *originalConstructor* which is the constructor object `new` was actually
 applied to. That argument also is also reified as arguments to the `construct` proxy trap and in `Reflect.construct`
 
-1.  Built-in object allocation and initialization are merged into a single constructor function, just like in ES5. Note that allocation take place in a base constructor rather than the original constructor and uses 'originalConstructor' argument to determine the [[Prototype]] of the new instance.  The subclass constructor determines what arguments are passed to the base constructor which may use those arguments in its allocation and initialization logic. 
+2.  Built-in object allocation and initialization are merged into a single constructor function, just like in ES5. Note that allocation take place in a base constructor rather than the original constructor and uses 'originalConstructor' argument to determine the [[Prototype]] of the new instance.  The subclass constructor determines what arguments are passed to the base constructor which may use those arguments in its allocation and initialization logic. 
 
     * There is no [[CreateAction]] or similar separable allocation step.
 
-1.  ***When a constructor is invoked via ordinary [[Construct]] and the constructor body was not defined using a `class` definition
+3.  ***When a constructor is invoked via ordinary [[Construct]] and the constructor body was not defined using a `class` definition
 that has an `extends` clause, then `this` is initialized to a newly allocated ordinary object whose [[Prototype]] is provided
 by the original constructor.
     * This is the way that `function` definition based constructors work today and must be maintained for legacy compatibility.  
     * The same `this` initializaton rules are used by both `function` definitions and `class` declarations that don't have `extends` clauses.
 
-1.  When a constructor is invoked via ordinary [[Construct]], `this` is marked as uninitialized if the constructor body was
+4.  When a constructor is invoked via ordinary [[Construct]], `this` is marked as uninitialized if the constructor body was
 defined using a `class` definition that has an `extends` clause. 
     * If invoked via [[Call]], 'this' is initialized in the normal manner.
 
-1.  Any explicit reference to an uninitialized `this` throws a TypeError Exception 
+5.  Any explicit reference to an uninitialized `this` throws a ReferenceError Exception 
 
-1.  When `this` is in its uninitialized state, any expression in a constructor of the form  `super(<args>)` accesses the
+6.  When `this` is in its uninitialized state, any expression in a constructor of the form  `super(<args>)` accesses the
 [[Prototype]] of the active function and invokes  [[Construct]] on it with the current *originalConstructor* value passed
 as the *originalConstructor* argument.   Subsequent references to `this` produce the object value that was returned from the
 superclass constructor.
     * In other words, a `super` call delegates allocation and initial initialization steps to the super class constructor. 
 
-1.  When `this` is in its initialized state, any expression of the form 'super(<args>)' throws a TypeError exception. 
+7.  When `this` is in its initialized state, any expression of the form 'super(<args>)' throws a TypeError exception. 
            Rather than using [[Call]] to invoke the super class constructor.  
 
-1.  *** Within a constructor, `new.target` can be used, as if it was an identifier, to access the *originalConstructor* value.
+8.  *** Within a constructor, `new.target` can be used, as if it was an identifier, to access the *originalConstructor* value.
     * `new.target` can be used to get information about the original constructor (such as its `prototype` property)
 that can be used to manually allocate the instance object. It can also be used to discriminate [[Construct]] vs. [[Call]] 
 invocations.
     * An explicit return must be used to return such manually allocated objects 
 
-1.  When a function implicitly returns from a [[Construct]] invocation, if its `this` binding is still uninitialized 
-a TypeError is thrown.  
+9.  When a function implicitly returns from a [[Construct]] invocation, if its `this` binding is still uninitialized 
+a ReferenceError is thrown.  
     * This covers the case where a constructor with an `extends` clause  does not  invokes `super()`.
 
-1.  When a function explicitly returns a non-object from a [[Construct]] invocation and its `this` binding 
+10.  When a function explicitly returns a non-object from a [[Construct]] invocation and its `this` binding 
 is still uninitialized a TypeError is thrown.  
 
-1.  When a function explicitly returns a non-object from a [[Construct]] invocation but the `this` value has been initialized, 
+11.  When a function explicitly returns a non-object from a [[Construct]] invocation but the `this` value has been initialized, 
 the `this` value is returned as the value of [[Construct]]
     * This is required for ES1-5 compatability
 
-1.  If a `class` definition does not include an explicit constructor definition, it defaults to: `constructor(...args) {super(...args)};` if the `class` has a non-null `extends` clause. Otherwise it defaults to: `constructor() {};`.
+12.  If a `class` definition does not include an explicit constructor definition, it defaults to: `constructor(...args) {super(...args)};` if the `class` has a non-null `extends` clause. Otherwise it defaults to: `constructor() {};`.
     * If you define a constructor body then you inherit both the constructor argument signature and body from your superclass.
 
 ** There is agreement that this functionality is necessary. There is not yet consensus as to whether it can be deferred 

--- a/meetings/2015-01/ES6-super-construct=proposal.md
+++ b/meetings/2015-01/ES6-super-construct=proposal.md
@@ -6,7 +6,7 @@ applied to. That argument also is also reified as arguments to the `construct` p
 
 1.  Built-in object allocation and initialization are merged into a single constructor function, just like in ES5. Note that allocation take place in a base constructor rather than the original constructor and uses 'originalConstructor' argument to determine the [[Prototype]] of the new instance.  The subclass constructor determines what arguments are passed to the base constructor which may use those arguments in its allocation and initialization logic. 
 
-    * There is no [[CreateAction]] of similar seperable allocation step.
+    * There is no [[CreateAction]] or similar separable allocation step.
 
 1.  *When a constructor is invoked via ordinary [[Construct]] and the constructor body was not defined using a `class` definition
 that has an `extends` clause, then `this` is initialized to a newly allocated ordinary object whose [[Prototype]] is provided
@@ -25,7 +25,7 @@ as the *originalConstructor* argument.   Subsequent references to `this` produce
 superclass constructor.
     * In other words, a `super` call delegates allocation and initial initialization steps to the super class constructor. 
 
-1.  When `this` is in its initialized state, any expression of the form 'super(<args>)' throws a TypeRrror exception. 
+1.  When `this` is in its initialized state, any expression of the form 'super(<args>)' throws a TypeError exception. 
            Rather than using [[Call]] to invoke the super class constructor.  
 
 1.  ** Within a constructor, `new.target` can be used, as if it was an identifier, to access the *originalConstructor* value.
@@ -39,7 +39,7 @@ a TypeError is thrown.
     * This covers the case where a constructor with an `extends` clause  does not  invokes `super()`.
 
 1.  When a function explicitly returns a non-object from a [[Construct]] invocation and its `this` binding 
-is still uninitialized an TypeError is thrown.  
+is still uninitialized a TypeError is thrown.  
 
 1.  When a function explicitly returns a non-object from a [[Construct]] invocation but the `this` value has been initialized, 
 the `this` valus is the value of [[Construct]]
@@ -51,5 +51,5 @@ the `this` valus is the value of [[Construct]]
 *if necessary this rule could be changed to only apply to `function` definition based constructors and `class` definitions 
 without an `extends` clause. 
 
-** There is agreement that this functionality is necessary. There is not yet concensus as to whetherer it can be deferred 
+** There is agreement that this functionality is necessary. There is not yet consensus as to whether it can be deferred 
 until ES7 and on the actual special form syntax used to access the value.

--- a/meetings/2015-01/ES6-super-construct=proposal.md
+++ b/meetings/2015-01/ES6-super-construct=proposal.md
@@ -29,7 +29,7 @@ superclass constructor.
 1.  When `this` is in its initialized state, any expression of the form 'super(<args>)' throws a TypeError exception. 
            Rather than using [[Call]] to invoke the super class constructor.  
 
-1.  ** Within a constructor, `new.target` can be used, as if it was an identifier, to access the *originalConstructor* value.
+1.  *** Within a constructor, `new.target` can be used, as if it was an identifier, to access the *originalConstructor* value.
     * `new.target` can be used to get information about the original constructor (such as its `prototype` property)
 that can be used to manually allocate the instance object. It can also be used to discriminate [[Construct]] vs. [[Call]] 
 invocations.
@@ -52,4 +52,4 @@ the `this` value is returned as the value of [[Construct]]
 ** There is agreement that this functionality is necessary. There is not yet consensus as to whether it can be deferred 
 until ES7 and on the actual special form syntax used to access the value.
 
-*** For the details covered by this proposal, an `extends null` clause  is considered to be equivalant to an absent `extends` clause.
+*** For the details covered by this proposal, an `extends null` clause  is considered to be equivalent to an absent `extends` clause.


### PR DESCRIPTION
Hi! This PR contains all these commits: https://github.com/tc39/ecma262/commits/83d11493e8c8bed337af1ccc58b53af0813c11cf/workingdocs/ES6-super-construct%3Dproposal.md which have been amended so the messages link to their original commit.

Once this lands, we can delete the document from ecma262 (since it doesn't really belong there).

I'd prefer to merge this with a merge commit, so that each commit remains in the git history on the default branch, which is important for archival purposes.